### PR TITLE
Fixes unexpected argument when calling tools.io.cireclvlRead 

### DIFF
--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -1515,7 +1515,7 @@ class ion(_ionTrails, _specTrails):
             #
             file = fileName +'.cilvl'
             if os.path.isfile(file):
-                self.Cilvl = io.cireclvlRead('',filename = fileName, cilvl=1)
+                self.Cilvl = io.cireclvlRead('',filename = fileName, filetype='cilvl')
                 self.Ncilvl=len(self.Cilvl['lvl1'])
                 nlvlCilvl = max(self.Cilvl['lvl2'])
                 nlvlList.append(nlvlCilvl)
@@ -1524,7 +1524,7 @@ class ion(_ionTrails, _specTrails):
             #  .reclvl file may not exist
             reclvlfile = fileName +'.reclvl'
             if os.path.isfile(reclvlfile):
-                self.Reclvl = io.cireclvlRead('',filename=fileName, reclvl=1)
+                self.Reclvl = io.cireclvlRead('',filename=fileName, filetype='reclvl')
                 self.Nreclvl = len(self.Reclvl['lvl1'])
                 nlvlReclvl = max(self.Reclvl['lvl2'])
                 nlvlList.append(nlvlReclvl)
@@ -1602,7 +1602,7 @@ class ion(_ionTrails, _specTrails):
         #
         file = fileName +'.cilvl'
         if os.path.isfile(file):
-            self.Cilvl = io.cireclvlRead('',filename = fileName, cilvl=1)
+            self.Cilvl = io.cireclvlRead('',filename = fileName, filetype='cilvl')
             self.Ncilvl=len(self.Cilvl['lvl1'])
 #            nlvlCilvl = max(self.Cilvl['lvl2'])
 #            nlvlList.append(nlvlCilvl)
@@ -1611,7 +1611,7 @@ class ion(_ionTrails, _specTrails):
         #  .reclvl file may not exist
         reclvlfile = fileName +'.reclvl'
         if os.path.isfile(reclvlfile):
-            self.Reclvl = io.cireclvlRead('',filename=fileName, reclvl=1)
+            self.Reclvl = io.cireclvlRead('',filename=fileName, filetype='reclvl')
             self.Nreclvl = len(self.Reclvl['lvl1'])
 #            nlvlReclvl = max(self.Reclvl['lvl2'])
 #            nlvlList.append(nlvlReclvl)

--- a/ChiantiPy/tools/io.py
+++ b/ChiantiPy/tools/io.py
@@ -125,7 +125,7 @@ def cireclvlRead(ions, filename=None, filetype='cilvl'):
     else:
         fname = util.ion2filename(ions)
 
-    paramname=fname+filetype
+    paramname=fname + '.' + filetype
 
     input=open(paramname,'r')
     lines = input.readlines()
@@ -166,7 +166,7 @@ def cireclvlRead(ions, filename=None, filetype='cilvl'):
         shortT = np.asarray(recdat[4:], 'float64')
         # the result of the next statement is to continue to replicate t
         t = np.resize(shortT, maxNtemp)
-        if rrlvl:
+        if filetype == 'rrlvl':
             temp[iline] = t
         else:
             temp[iline] = 10.**t


### PR DESCRIPTION
Fixing something that I broke...

I previously combined the three arguments `cilvl=0,reclvl=0,rrlvl=0` into a single `filetype='cilvl'`, but forgot to adjust calls to `cireclvlRead` appropriately.

This PR fixes calls to `cireclvlRead` to use the new `filetype` argument. It also makes some small fixes in `cireclvlRead` again due to changing these input arguments.

Users may have encountered this error when calculating ionization equilibrium using `core.Ion.ioneq`
