### PR TITLE
Remove conflict markers

### DIFF
--- a/ChiantiPy/tools/constants.py
+++ b/ChiantiPy/tools/constants.py
@@ -73,13 +73,9 @@ Ionstage = ['I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII','XIII'
     'XIV','XV','XVI','XVII','XVIII','XIX','XX','XXI',' XXII','XXIII','XXIV', \
     'XXV','XXVI','XXVII','XXVIII','XXIX','XXX','XXXI','XXXII','XXXIII','XXXIV', \
     'XXXV','XXXVI','XXXVII']
-<<<<<<< HEAD:ChiantiPy/tools/constants.py
 Spd = ['S', 'P', 'D', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'O', 'Q', 'R', 'T', 'U', 'V', 'W', \
        'X','Y', 'Z', 'A','B', 'C', 'S1', 'P1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'K1', 'L1', \
        'M1', 'N1', 'O1', 'Q1', 'R1', 'T1', 'U1', 'V1', 'W1','X1','Y1', 'Z1', 'A1','B1', 'C1']
-=======
-Spd = ['S', 'P', 'D', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'O', 'Q', 'R', 'T', 'U', 'V', 'W','X','Y', 'Z', 'A','B', 'C', 'S1', 'P1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'K1', 'L1', 'M1', 'N1', 'O1', 'Q1', 'R1', 'T1', 'U1', 'V1', 'W1','X1','Y1', 'Z1', 'A1','B1', 'C1']
->>>>>>> 4f86943e9c6f77a9f3b104403da5fef5f7207044:ChiantiPy/tools/constants.py
 #
 #  data for Gauss-Laguerre integration
 #

--- a/ChiantiPy/tools/io.py
+++ b/ChiantiPy/tools/io.py
@@ -70,12 +70,8 @@ def zion2name(z,ion, dielectronic=False):
     """
     Convert `Z` and `ion` to generic name, e.g. 26, 13 -> fe_13
     (A duplicate of the routine in util but needed by masterList Info
-<<<<<<< HEAD:ChiantiPy/tools/io.py
-    TODO: can we remove the duplicate? - it is duplicated because both modules need it, 
+    TODO: can we remove the duplicate? - it is duplicated because both modules need it,
     otherwise, get into circular imports)
-=======
-    TODO: can we remove the duplicate?)
->>>>>>> 4f86943e9c6f77a9f3b104403da5fef5f7207044:ChiantiPy/tools/io.py
     """
     if ion == 0:
         thisone = 0
@@ -95,12 +91,8 @@ def convertName(name):
     """
     Convert ion name string to Z and Ion
     (A duplicate of the routine in util but needed by masterList Info
-<<<<<<< HEAD:ChiantiPy/tools/io.py
     TODO: Can we remove this duplicate? - it is duplicated because both modules need it, 
     otherwise, get into circular imports)
-=======
-    TODO: Can we remove this duplicate?)
->>>>>>> 4f86943e9c6f77a9f3b104403da5fef5f7207044:ChiantiPy/tools/io.py
     """
     s2=name.split('_')
     els=s2[0].strip()


### PR DESCRIPTION
When merging PR #21, we resolved some conflicts, but in the merge, some conflict markers (e.g. `>>>>>> HEAD`) were left behind in `constants.py` and `io.py`. This PR just removes those markers. 
