### PR TITLE
Add support for continuous integration via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,14 @@ env:
     - ASTROPY_VERSION='stable'
     - MAIN_CMD='python setup.py'
     - SETUP_CMD='install'
-    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt'
+    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme'
   matrix:
-    - PYTHON_VERSION=2.7
-    - PYTHON_VERSION=3.4
-    - PYTHON_VERSION=3.5
+    - PYTHON_VERSION=2.7 SETUP_CMD='install'
+    - PYTHON_VERSION=3.4 SETUP_CMD='install'
+    - PYTHON_VERSION=3.5 SETUP_CMD='install'
+    - PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx'
+    - PYTHON_VERSION=3.4 SETUP_CMD='build_sphinx'
+    - PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx'
 #install the ci helpers
 install:
   - git clone https://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 #set up the build matrix for multiple versions of python
 env:
   global:
+    - XUVTOP=$HOME"/chianti_dbase"
     - PYTHON_VERSION=2.7
     - NUMPY_VERSION='stable'
     - ASTROPY_VERSION='stable'
@@ -22,6 +23,10 @@ env:
 install:
   - git clone https://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda_${TRAVIS_OS_NAME}.sh
+#install the chianti database
+before_script:
+  - mkdir -p $XUVTOP
+  - curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.2_data.tar.gz | tar xz -C $XUVTOP
 #run the setup commands
 script:
   - $MAIN_CMD $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+#set language to c because we are using conda to install everything
+language: c
+sudo: false
+#set environment variables for versions of different packages
+#set up the build matrix for multiple versions of python
+env:
+  global:
+    - PYTHON_VERSION=2.7
+    - NUMPY_VERSION='stable'
+    - ASTROPY_VERSION='stable'
+    - MAIN_CMD='python setup.py'
+    - SETUP_CMD='install'
+    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt'
+  matrix:
+    - PYTHON_VERSION=2.7
+    - PYTHON_VERSION=3.4
+    - PYTHON_VERSION=3.5
+#install the ci helpers
+install:
+  - git clone https://github.com/astropy/ci-helpers.git
+  - source ci-helpers/travis/setup_conda_${TRAVIS_OS_NAME}.sh
+#run the setup commands
+script:
+  - $MAIN_CMD $SETUP_CMD

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,8 +42,11 @@ except ImportError:
 from astropy_helpers.sphinx.conf import *
 
 # Get configuration information from setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,11 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
This PR adds a `.travis.yml` file that does a `setup.py install` for Python 2.7, 3.4,3.5 and addresses Issue #32. It uses [astropy ci-helpers](https://github.com/astropy/ci-helpers) to do all of the installation with conda. This will help to ensure that new changes introduced with PRs at the very least don't break at the install stage before they are merged. 

Later on if a more robust test suite is added, it is only a few minor changes in the file to also run the entire test suite for each Python version.

@kdere to enable automatic builds for the ChiantiPy repo, just go to the [Travis CI webpage](https://travis-ci.org), sign in with your GitHub credentials, and enable the build by "flipping the switch" in your list of repos. 

This PR also includes two very minor Python 2-to-3 compatibility fixes so that the install passes for all versions.
