### PR TITLE
Force PyQt to be version 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - MAIN_CMD='python setup.py'
     - SETUP_CMD='install'
     - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme'
+    - PYQT_VERSION='4.11.4'
   matrix:
     - PYTHON_VERSION=2.7 SETUP_CMD='install'
     - PYTHON_VERSION=3.4 SETUP_CMD='install'


### PR DESCRIPTION
Travis sphinx build is failing and RTD is hanging. Travis seems to be failing because of a PyQt update . This forces PyQt to version 4. ~~Maybe this will fix it?~~ Checks passed!