### PR TITLE
abundanceName kwarg consistency fix

### DIFF
--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -41,14 +41,12 @@ class ion(ionTrails, specTrails):
         Radiation black-body temperature (in Kelvin)
     rStar : `~numpy.float64` or `~numpy.ndarray`, optional
         Distance from the center of the star (in stellar radii)
-    abundanceName : `str`, optional
-        Name of Chianti abundance file to use, without the '.abund' suffix,
-        e.g. 'sun_photospheric_1998_grevesse'. Ignored if `abundance` is set.
-    abundance : `float or ~numpy.float64`, optional
-        Elemental abundance relative to Hydrogen
-    setup : `bool or str`, optional
-        If True, run ion setup function
-        Otherwise, provide a limited number of attributes of the selected ion
+    abundance : `float` or `str`, optional
+        Elemental abundance relative to Hydrogen or name of CHIANTI abundance file
+        to use, without the '.abund' suffix, e.g. 'sun_photospheric_1998_grevesse'.
+    setup : `bool` or `str`, optional
+        If True, run ion setup function. Otherwise, provide a limited number of
+        attributes of the selected ion
     em : `~numpy.float64` or `~numpy.ndarray`, optional
         Emission Measure, for the line-of-sight emission measure
         (:math:`\mathrm{\int \, n_e \, n_H \, dl}`)

--- a/ChiantiPy/core/RadLoss.py
+++ b/ChiantiPy/core/RadLoss.py
@@ -167,7 +167,7 @@ class radLoss(specTrails):
             if 'line' in self.Todo[akey]:
                 if verbose:
                     print(' calculating spectrum for  :  %s'%(akey))
-                thisIon = ChiantiPy.core.ion(akey, temperature, eDensity, abundanceName=self.AbundanceName)
+                thisIon = ChiantiPy.core.ion(akey, temperature, eDensity, abundance=self.AbundanceName)
                 thisIon.intensity(allLines=allLines)
                 self.IonsCalculated.append(akey)
                 if 'errorMessage' not in  list(thisIon.Intensity.keys()):

--- a/ChiantiPy/core/Spectrum.py
+++ b/ChiantiPy/core/Spectrum.py
@@ -207,7 +207,7 @@ class spectrum(ionTrails, specTrails):
             if 'line' in self.Todo[akey]:
                 if verbose:
                     print(' calculating spectrum for  :  %s'%(akey))
-                thisIon = ChiantiPy.core.ion(akey, temperature, eDensity, abundanceName=self.AbundanceName)
+                thisIon = ChiantiPy.core.ion(akey, temperature, eDensity, abundance=self.AbundanceName)
                 thisIon.intensity(wvlRange=wvlRange, allLines=allLines, em=em)
                 self.IonsCalculated.append(akey)
                 if 'errorMessage' not in  list(thisIon.Intensity.keys()):


### PR DESCRIPTION
As of PR #51, Ion class now uses `abundance` kwarg to set either the abundance using a float or the abundance filename with a string. This was previously done with two kwargs, `abundance` and `abundanceName`. This PR fixes calls to the ion class by the spectrum and radloss classes and updates the ion docstring appropriately.