### PR TITLE
Write the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,15 @@ env:
     - ASTROPY_VERSION='stable'
     - MAIN_CMD='python setup.py'
     - SETUP_CMD='install'
-    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme'
+    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme pytest'
     - PYQT_VERSION='4.11.4'
   matrix:
     - PYTHON_VERSION=2.7 SETUP_CMD='install'
     - PYTHON_VERSION=3.4 SETUP_CMD='install'
     - PYTHON_VERSION=3.5 SETUP_CMD='install'
+    - PYTHON_VERSION=2.7 SETUP_CMD='test'
+    - PYTHON_VERSION=3.4 SETUP_CMD='test'
+    - PYTHON_VERSION=3.5 SETUP_CMD='test'
     - PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx'
     - PYTHON_VERSION=3.4 SETUP_CMD='build_sphinx'
     - PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx'
@@ -24,8 +27,10 @@ env:
 install:
   - git clone https://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda_${TRAVIS_OS_NAME}.sh
-#install the chianti database
+#install the chianti database and place rc file
 before_script:
+  - mkdir -p $HOME/.chianti
+  - cp chiantirc $HOME/.chianti
   - mkdir -p $XUVTOP
   - curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.2_data.tar.gz | tar xz -C $XUVTOP
 #run the setup commands

--- a/ChiantiPy/__init__.py
+++ b/ChiantiPy/__init__.py
@@ -5,7 +5,7 @@ This is not yet an Astropy affiliated package, but it makes use of the Astropy p
 '''
 # Include this stuff for astropy affiliation
 # -------------------------------------------
-#from ._astropy_init import *
+from ._astropy_init import *
 #--------------------------------------------
 
 #if not _ASTROPY_SETUP_:

--- a/ChiantiPy/__init__.py
+++ b/ChiantiPy/__init__.py
@@ -8,16 +8,7 @@ This is not yet an Astropy affiliated package, but it makes use of the Astropy p
 from ._astropy_init import *
 #--------------------------------------------
 
-#if not _ASTROPY_SETUP_:
-#    # For ChiantiPy
-#    from . import  version
-#    Version = version._last_generated_version
-#
-try:
-    from .version import version as __version__
-except ImportError:
-    __version__ = '0.7.0'
-try:
-    from .version import githash as __githash__
-except ImportError:
-    __githash__ = ''
+if not _ASTROPY_SETUP_:
+    # For ChiantiPy
+    from . import  version
+    Version = version._last_generated_version

--- a/ChiantiPy/conftest.py
+++ b/ChiantiPy/conftest.py
@@ -1,0 +1,38 @@
+# this contains imports plugins that configure py.test for astropy tests.
+# by importing them here in conftest.py they are discoverable by py.test
+# no matter how it is invoked within the source tree.
+
+from astropy.tests.pytest_plugins import *
+
+## Uncomment the following line to treat all DeprecationWarnings as
+## exceptions
+# enable_deprecations_as_exceptions()
+
+## Uncomment and customize the following lines to add/remove entries from
+## the list of packages for which version numbers are displayed when running
+## the tests. Making it pass for KeyError is essential in some cases when
+## the package uses other astropy affiliated packages.
+# try:
+#     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+#     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+#     del PYTEST_HEADER_MODULES['h5py']
+# except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
+#     pass
+
+## Uncomment the following lines to display the version number of the
+## package rather than the version number of Astropy in the top line when
+## running the tests.
+# import os
+#
+## This is to figure out the affiliated package version, rather than
+## using Astropy's
+# try:
+#     from .version import version
+# except ImportError:
+#     version = 'dev'
+#
+# try:
+#     packagename = os.path.basename(os.path.dirname(__file__))
+#     TESTED_VERSIONS[packagename] = version
+# except NameError:   # Needed to support Astropy <= 1.0.0
+#     pass

--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -157,8 +157,8 @@ class ion(ionTrails, specTrails):
             elif self.EDensity.size == 1 and self.Temperature.size > 1:
                 self.EDensity = np.ones_like(self.Temperature)*self.EDensity
 
-        if hasattr(self,'EDensity') and hasattr(self,'Temperature') and \
-            self.EDensity.size != self.Temperature.size:
+        if hasattr(self,'EDensity') and hasattr(self,'Temperature') \
+        and self.EDensity.size != self.Temperature.size:
             raise ValueError('Temperature and density must be the same size.')
 
         if pDensity == 'default' and eDensity is not None:

--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -157,8 +157,9 @@ class ion(ionTrails, specTrails):
             elif self.EDensity.size == 1 and self.Temperature.size > 1:
                 self.EDensity = np.ones_like(self.Temperature)*self.EDensity
 
-        if hasattr(self,'EDensity') and hasattr(self,'Temperature'):
-            assert self.EDensity.size == self.Temperature.size,'Temperature and eDensity must have the same size.'
+        if hasattr(self,'EDensity') and hasattr(self,'Temperature') and \
+            self.EDensity.size != self.Temperature.size:
+            raise ValueError('Temperature and density must be the same size.')
 
         if pDensity == 'default' and eDensity is not None:
             self.PDensity = self.ProtonDensityRatio*self.EDensity

--- a/ChiantiPy/core/tests/test_Continuum.py
+++ b/ChiantiPy/core/tests/test_Continuum.py
@@ -1,0 +1,42 @@
+"""
+Tests for the continuum class
+"""
+
+import numpy as np
+import pytest
+
+from ChiantiPy.core import continuum
+
+# test ion
+test_ion = 'fe_15'
+# set some wavelength and temperature arrays
+temperature_1 = 1e+6
+temperature_2 = np.logspace(5,8,10)
+wavelength = np.linspace(10,100,100)
+# create continuum object for testing
+tmp_cont = continuum(test_ion,temperature_2)
+
+
+# test temperature input
+def test_temperature():
+    _tmp_cont = continuum(test_ion,temperature_1)
+    assert np.array(temperature_1)==temperature_1
+    _tmp_cont = continuum(test_ion,temperature_2)
+    assert np.all(temperature_2==tmp_cont.Temperature)
+
+# test the free-free calculation
+def test_freeFree():
+    # call free-free continuum method
+    tmp_cont.freeFree(wavelength)
+    assert hasattr(tmp_cont,'FreeFree')
+    # check that all expected keys are there
+    # FIXME: need to check 'ff' key too but conditions when it should be there are not clear
+    assert all((k in tmp_cont.FreeFree for k in ('rate','temperature','wvl') ))
+
+# test the free-bound calculation
+def test_freeBound():
+    # free-bound continuum methods
+    tmp_cont.freeBound(wavelength)
+    assert hasattr(tmp_cont,'FreeBound')
+    # check that all expected keys are there
+    assert all((k in tmp_cont.FreeBound for k in ('rate','temperature','wvl') ))

--- a/ChiantiPy/core/tests/test_Ion.py
+++ b/ChiantiPy/core/tests/test_Ion.py
@@ -1,0 +1,73 @@
+"""
+Tests for the ion and ioneq classes.
+"""
+
+import numpy as np
+import pytest
+
+from ChiantiPy.core import ion,ioneq
+import ChiantiPy.tools as ch_tools
+
+# use an ion with relatively small chianti files
+test_ion = 'fe_15'
+# TODO: probably should check a few different ions, i.e. dielectronic, some without certain kinds
+# files, etc.
+# set a few temperature and density arrays
+temperature_1 = 1e+6
+temperature_2 = np.logspace(5,8,20)
+density_1 = 1e+9
+density_2 = np.logspace(5,8,20)
+density_3 = np.logspace(5,8,21)
+# setup an ion object to reuse in several tests
+tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_2)
+
+#Check various ways to specify the temperature and density
+def test_temperature_density():
+    # TODO: test case where neither are set/ one or the other is not set
+    # Two single values
+    _tmp_ion = ion(test_ion,temperature=temperature_1,eDensity=density_1,setup=False)
+    assert _tmp_ion.Temperature==np.array(temperature_1)
+    assert _tmp_ion.EDensity==np.array(density_1)
+    # Multiple temperatures, one density
+    _tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_1,setup=False)
+    assert np.all(_tmp_ion.Temperature==temperature_2)
+    assert np.all(_tmp_ion.EDensity==np.array(temperature_2.size*[density_1]))
+    # One temperature, multiple densities
+    _tmp_ion = ion(test_ion,temperature=temperature_1,eDensity=density_2,setup=False)
+    assert np.all(_tmp_ion.Temperature==np.array(density_2.size*[temperature_1]))
+    assert np.all(_tmp_ion.EDensity==density_2)
+    # Two equal-sized temperature and density arrays
+    _tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_2,setup=False)
+    assert np.all(_tmp_ion.Temperature==temperature_2)
+    assert np.all(_tmp_ion.EDensity==density_2)
+    # Two unequal sized temperature and density arrays
+    with pytest.raises(ValueError,
+                        message='''Expecting ValueError when temperature and density are not of
+                                equal size.'''):
+        _tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_3,setup=False)
+
+#Check how abundance is set
+def test_abundance():
+    # Float value
+    _tmp_ion = ion(test_ion,abundance=0.01,setup=False)
+    assert _tmp_ion.Abundance==0.01
+    # FIXME: if setting custom abundance, AbundanceName should not be set, but right
+    # now it is by the proton/electron density ratio calculation.
+    # Custom filename
+    _tmp_ion = ion(test_ion,abundance='sun_coronal_2012_schmelz',setup=False)
+    assert _tmp_ion.AbundanceName=='sun_coronal_2012_schmelz'
+    abundance = ch_tools.io.abundanceRead(abundancename='sun_coronal_2012_schmelz')
+    assert _tmp_ion.Abundance==abundance['abundance'][_tmp_ion.Z-1]
+
+#Check CHIANTI file imports
+def test_chianti_files():
+    assert hasattr(tmp_ion,'Elvlc')
+    assert hasattr(tmp_ion,'Wgfa')
+    if tmp_ion.Nscups>0:
+        assert hasattr(tmp_ion,'Scups')
+    if tmp_ion.Ncilvl>0:
+        assert hasattr(tmp_ion,'Cilvl')
+    if tmp_ion.Nreclvl>0:
+        assert hasattr(tmp_ion,'Reclvl')
+    if tmp_ion.Npsplups>0:
+        assert hasattr(tmp_ion,'Psplups')

--- a/ChiantiPy/core/tests/test_Ion.py
+++ b/ChiantiPy/core/tests/test_Ion.py
@@ -21,6 +21,7 @@ density_3 = np.logspace(5,8,21)
 # setup an ion object to reuse in several tests
 tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_2)
 
+
 #Check various ways to specify the temperature and density
 def test_temperature_density():
     # TODO: test case where neither are set/ one or the other is not set

--- a/ChiantiPy/core/tests/test_RadLoss.py
+++ b/ChiantiPy/core/tests/test_RadLoss.py
@@ -1,0 +1,3 @@
+"""
+Tests for the radloss class
+"""

--- a/ChiantiPy/core/tests/test_RadLoss.py
+++ b/ChiantiPy/core/tests/test_RadLoss.py
@@ -1,3 +1,20 @@
 """
 Tests for the radloss class
 """
+
+import pytest
+import numpy as np
+
+from ChiantiPy.core import radLoss
+
+temperature = np.logspace(5,8,20)
+density = 1e+9
+minAbund=1e-4
+
+#FIXME: should probably look at more cases
+def test_radloss():
+    tmp_radloss = radLoss(temperature,density,minAbund=minAbund)
+    assert all((k in tmp_radloss.RadLoss for k in ('rate','temperature','density','minAbund',
+                                                    'abundance')))
+
+#TODO: test plotting

--- a/ChiantiPy/core/tests/test_Spectrum.py
+++ b/ChiantiPy/core/tests/test_Spectrum.py
@@ -1,3 +1,27 @@
 """
-Tests for the spectrum class
+Tests for the spectrum and bunch classes
 """
+
+import numpy as np
+import pytest
+
+from ChiantiPy.core import spectrum,bunch
+
+#set temperature, density, wavelength
+temperature_1 = np.array([1e+6,4e+6,1e+7])
+temperature_2 = np.logspace(5,8,10)
+density = 1e+9
+wavelength = np.linspace(10,100,1000)
+wavelength_range = [wavelength[0],wavelength[-1]]
+min_abund=1.e-4
+ion_list = ['fe_15','fe_16']
+
+# test the spectrum class
+def test_spectrum():
+    _tmp_spec = spectrum(temperature_1,density,wavelength,minAbund=min_abund)
+    # TODO: need to assert something here, not clear what exactly to test yet
+
+# test the bunch class
+def test_bunch():
+    _tmp_bunch = bunch(temperature_2,density,wvlRange=wavelength_range,ionList=ion_list)
+    # TODO: need to assert something here, not clear what exactly to test yet

--- a/ChiantiPy/core/tests/test_Spectrum.py
+++ b/ChiantiPy/core/tests/test_Spectrum.py
@@ -1,0 +1,3 @@
+"""
+Tests for the spectrum class
+"""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+norecursedirs = build *.egg-info astropy_helpers
+addopts = -p no:doctest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 norecursedirs = build *.egg-info astropy_helpers
+python_files = test_?*.py
 addopts = -p no:doctest

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.7.0'
+VERSION = '0.6.5'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
Provides tests (per Issue #54) for all of the non-base classes in the core module. Most are very minimal and need to be improved in the future. However, these tests at least ensure that the main objects can be created and in some cases (e.g. `continuum`) a few methods are tested. 

To run the tests, `python setup.py test`. All tests should be placed in a directory `tests` within the respective module. Each file should then be labeled `test_{{ name of file containing functions/objects you are writing tests for}}.py`. 

Note that I've reintroduced a dependency on Astropy by uncommenting the astropy_init line in setup.py. This is to that ChiantiPy can use the already-in-place astropy testing framework. 

As I said, these are very minimal tests, but will help catch simple mistakes that break basic functionality. This only covers core module so the tools module remains untested. The Travis YML file has been modified so that these tests are run at each PR/merge.

Now that these tests are in place, we should avoid merging PRs (including this one!) until all tests have passed to avoid breaking the master build.

I've also bumped the version down to 0.6.5 ( in the setup.py file) to be consistent with the latest release.