### PR TITLE
Fix abundance kwarg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
     - NUMPY_VERSION='stable'
     - ASTROPY_VERSION='stable'
     - MAIN_CMD='python setup.py'
-    - SETUP_CMD='install'
     - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme pytest'
     - PYQT_VERSION='4.11.4'
   matrix:

--- a/ChiantiPy/core/RadLoss.py
+++ b/ChiantiPy/core/RadLoss.py
@@ -131,7 +131,7 @@ class radLoss(specTrails):
                     print(' calculating ff continuum for :  %s'%(akey))
                 if 'ff' in self.Todo[akey]:
                     # need to skip the neutral
-                        cont = ChiantiPy.core.continuum(akey, temperature, abundanceName=self.AbundanceName)
+                        cont = ChiantiPy.core.continuum(akey, temperature, abundance=self.AbundanceName)
                         cont.freeFreeLoss()
                         freeFreeLoss += cont.FreeFreeLoss['rate']
                 if 'fb' in self.Todo[akey]:
@@ -142,7 +142,7 @@ class radLoss(specTrails):
                     if hasattr(cont, 'FreeFreeLoss'):
                         cont.freeBoundLoss()
                     else:
-                        cont = ChiantiPy.core.continuum(akey, temperature, abundanceName=self.AbundanceName)
+                        cont = ChiantiPy.core.continuum(akey, temperature, abundance=self.AbundanceName)
                         cont.freeBoundLoss()
                     if 'errorMessage' not in list(cont.FreeBoundLoss.keys()):
                         #  an fblvl file exists for this ions


### PR DESCRIPTION
Fixes Issue #67 from PR #66.

`continuum` in `radLoss` used the old-style `abundanceName` kwarg. Failing because `continuum` only accepts `abundance` (can be float or filename) as of #66.