### PR TITLE
cleanup, removed easplomRead, added scale_classical

### DIFF
--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -555,15 +555,16 @@ class ion(ionTrails, specTrails):
             self.DiParams = io.diRead(self.IonStr)
         if self.DiParams['info']['neaev'] == 0:
             #FIXME: raise an error here?
+            # basically, this means that this method should not be invoked
             return
         else:
             if hasattr(self, 'Temperature'):
                 temperature=self.Temperature
             else:
-                bte=0.1*np.arange(10)
-                bte[0]=0.01
+                btT=0.1*np.arange(10)
+                btT[0]=0.01
                 dum=np.ones(10, 'Float64')
-                [temperature, dum]=util.descale_bt(bte, dum, self.EaParams['cups'][0], self.DiParams['de'][0])
+                [temperature, dum] = util.descale_bt(btT, dum, self.EaParams['cups'][0], self.DiParams['de'][0])
                 self.Temperature=temperature
             if hasattr(self, 'EaParams'):
                 eaparams=self.EaParams

--- a/ChiantiPy/tools/io.py
+++ b/ChiantiPy/tools/io.py
@@ -145,14 +145,6 @@ def cireclvlRead(ions, filename=None, filetype='cilvl'):
     ndata = iline - 1
     ntrans = ndata//2
     #
-#    nref = 0
-#    idx = -1
-#    while idx < 0:
-#        aline=lines[iline][0:5]
-#        idx=aline.find('-1')
-#        iline += 1
-#        nref += 1
-#    nref -= 1
     #
     # need to find the maximum number of temperatures, not all lines are the same
     #
@@ -276,15 +268,7 @@ def diRead(ions, filename=None):
     if neaev:
         line=input.readline()
         eacoef=line.split()
-#            print ' eaev = ', type(eacoef), eacoef
         eaev=[float(avalue) for avalue in eacoef]
-#            print ' eaev = ', type(eaev), eaev
-#            print ' eaev = ', type(eaev), eaev
-#            if len(eaev) == 1:
-#                eaev=float(eaev[0])
-#                eaev=np.asarray(eaev, 'float32')
-#            else:
-#                eaev=np.asarray(eaev, 'float32')
     else:
         eaev=0.
     hdr=input.readlines()
@@ -415,70 +399,8 @@ def eaRead(ions, filename=None):
         for i in range(nsplups+1,len(s1)):
             s1a=s1[i][:-1]
             ref.append(s1a.strip())
-#        self.EaParams={"lvl1":lvl1,"lvl2":lvl2,"ttype":ttype,"gf":gf,"de":de,"cups":cups
-#                ,"nspl":nspl,"splups":splups,"ref":ref}
-        return {"lvl1":lvl1,"lvl2":lvl2,"ttype":ttype,"gf":gf,"de":de,"cups":cups
+    return {"lvl1":lvl1,"lvl2":lvl2,"ttype":ttype,"gf":gf,"de":de,"cups":cups
                 ,"nspl":nspl,"splups":splups,"ref":ref}
-
-
-def easplomRead(ions, filename=0, extension='.splom'):
-    """
-    Read CHIANTI splom files for `ions`.
-
-    Notes
-    -----
-    Currently only works for 5 point spline fit files. `splomRead` probably does just as good a job - this function may be redundant.
-    """
-    #
-    #
-    if filename:
-        input = open(filename)
-    else:
-        fname=ion2filename(ions)
-        omname=fname+extension
-        input=open(omname,'r')
-    lines=input.readlines()
-    input.close()
-    format=FortranFormat('5i3,8e10.3')
-    data=5
-    iline=0
-    lvl1=[]
-    lvl2=[]
-    ttype=[]
-    gf=[]
-    de=[]
-    om=[]
-    z=1
-    while z > 0:
-        omdat1=FortranLine(lines[iline],format)
-        z=omdat1[0]
-        if z > 0:
-            l1=omdat1[2]
-            l2=omdat1[3]
-            ttype1=omdat1[4]
-            gf1=omdat1[5]
-            de1=omdat1[6]
-            btf1=omdat1[7]
-            om1=omdat1[8:]
-            #
-            lvl1.append(l1)
-            lvl2.append(l2)
-            ttype.append(ttype1)
-            gf.append(gf1)
-            de.append(de1)
-            om.append(om1)
-        iline=iline+1
-    omout=np.asarray(om,'Float64')
-    ref=lines[iline:-1]
-#        omout=np.transpose(omout)
-#    if extension == '.omdat':
-#        Splom={"lvl1":lvl1,"lvl2":lvl2,'ttype':ttype,"gf":gf, "deryd":de,"omega":omout, 'ref':ref}
-#        return Splom
-#    elif  extension == '.easplom':
-#        Easplom={"lvl1":lvl1,"lvl2":lvl2,'ttype':ttype,"gf":gf, "deryd":de,"omega":omout, 'ref':ref}
-#        return Easplom
-    Splom={"lvl1":lvl1,"lvl2":lvl2,'ttype':ttype,"gf":gf, "deryd":de,"omega":omout, 'ref':ref}
-    return Splom
 
 
 def elvlcRead(ions, filename=None, getExtended=False, verbose=False, useTh=True):
@@ -575,8 +497,6 @@ def elvlcRead(ions, filename=None, getExtended=False, verbose=False, useTh=True)
     for i in range(nlvls+1,len(s1)):
         s1a=s1[i]
         ref.append(s1a.strip())
-#    self.const.Elvlc={"lvl":lvl,"conf":conf,"term":term,"spin":spin,"l":l,"spd":spd,"j":j
-#            ,"mult":mult,"ecm":ecm,"eryd":eryd,"ecmth":ecmth,"erydth":erydth,"ref":ref}
     info = {"lvl":lvl,"conf":conf, "term":term,'label':label, "spin":spin, "spd":spd, "l":l, "j":j,
              'mult':mult, "ecm":ecm, 'eryd':eryd,'erydth':erydth, "ecmth":ecmth, "ref":ref,
              "pretty":pretty, 'status':status, 'filename':elvlname}
@@ -944,53 +864,6 @@ def ioneqRead(ioneqname='', verbose=False):
         ioneqRef.append(one[:-1])  # gets rid of the \n
     del s1
     return {'ioneqname':ioneqname,'ioneqAll':ioneqAll,'ioneqTemperature':ioneqTemperature,'ioneqRef':ioneqRef}
-
-
-#def ionrecdatRead(filename):
-#    """
-#    read chianti ionxdat, ionizdat, recombdat files and return
-#    {"ev":ev,"cross":cross,"crosserr":crosserr,"ref":ref}
-#    as of 10/28/2014, this routine does not seem to be used any more
-#    """
-#    #
-#    input=open(filename,'r')
-#    ionrec=input.readlines()
-#    dum=input.close()
-#    #
-#    # first get the number of data lines
-#    ndata=2
-#    iline=0
-#    while ndata > 1:
-#        s2=ionrec[iline].split()
-#        ndata=len(s2)
-#        iline=iline+1
-#    nline=iline-1
-#    #
-#    x=np.zeros(nline,'Float64')
-#    y=np.zeros(nline,'Float64')
-#    yerr=np.zeros(nline,'Float64')
-#    #
-#    for iline in range(0,nline):
-#        ndata=len
-#        s2=ionrec[iline].split()
-#        ndata=len(s2)
-#        if ndata == 2:
-#            x[iline]=float(s2[0])
-#            y[iline]=float(s2[1])
-#            yerr[iline]=float(0.)
-#        else:
-#            x[iline]=float(s2[0])
-#            y[iline]=float(s2[1])
-#            yerr[iline]=float(s2[2])
-#    #
-#    ref=[]
-#    for iline in range(nline+1,len(ionrec)-1):
-#        s1a=ionrec[iline][:-1]
-#        ref.append(s1a.strip())
-#
-#
-#    ionrecdat={"x":x,"y":y,"yerr":yerr,"ref":ref}
-#    return ionrecdat
 
 
 def ipRead(verbose=False):

--- a/ChiantiPy/tools/util.py
+++ b/ChiantiPy/tools/util.py
@@ -450,61 +450,21 @@ def scale_bti(evin,crossin,f,ev1):
 
     Notes
     -----
-    This is the scaling used and discussed in the Dere (2007) calculation [2] of cross sections.  It was derived from similar scalings derived in reference [1]
+    This is the scaling used and discussed in the Dere (2007) calculation [1] of cross sections.  It was derived from similar scalings derived in reference [2]
 
     See Also
     --------
-    scale_bti : Descale ionization energy and cross-section
+    descale_bti : Descale ionization energy and cross-section
 
     References
     ----------
-    .. [1] Burgess, A. and Tully, J. A., 1992, A&A, `254, 436 <http://adsabs.harvard.edu/abs/1992A%26A...254..436B>`_
-    .. [2] Dere, K. P., 2007, A&A, `466, 771, <http://adsabs.harvard.edu/abs/2007A%26A...466..771D>`_
+    .. [1] Dere, K. P., 2007, A&A, `466, 771, <http://adsabs.harvard.edu/abs/2007A%26A...466..771D>`_
+    .. [2] Burgess, A. and Tully, J. A., 1992, A&A, `254, 436 <http://adsabs.harvard.edu/abs/1992A%26A...254..436B>`_
     """
     u = evin/ev1
     bte = 1.-np.log(f)/np.log(u-1.+f)
     btx = u*crossin*(ev1**2)/(np.log(u)+1.)
     return [bte,btx]
-
-
-def descale_bti(bte,btx,f,ev1):
-    """
-    Apply ionization descaling of [1]_ to energy and cross-section.
-
-    Parameters
-    ----------
-    bte : array-like
-        Scaled energy
-    btx : array-like
-        Scaled cross-section
-    f : float
-        Scaling parameter
-    ev1 : float
-        ionization potential - units determine the output energy units
-
-    Returns
-    -------
-    [energy,cross] : `list`
-        Descaled energy and cross-section
-
-    Notes
-    -----
-    This is the scaling used and discussed in the Dere (2007) calculation [2] of cross sections.  It was derived from similar scalings derived in reference [1]
-
-    See Also
-    --------
-    scale_bti : Descale ionization energy and cross-section
-
-    References
-    ----------
-    .. [1] Burgess, A. and Tully, J. A., 1992, A&A, `254, 436 <http://adsabs.harvard.edu/abs/1992A%26A...254..436B>`_
-    .. [2] Dere, K. P., 2007, A&A, `466, 771, <http://adsabs.harvard.edu/abs/2007A%26A...466..771D>`_
-    """
-    u = 1.-f + np.exp(np.log(f)/(1. - bte))
-    energy = u*ev1
-    cross = (np.log(u)+1.)*btx/(u*ev1**2)
-    return [energy,cross]
-
 
 def descale_bt(bte,btomega,f,ev1):
     """
@@ -542,6 +502,45 @@ def descale_bt(bte,btomega,f,ev1):
     return [energy,omega]
 
 
+def descale_bti(bte,btx,f,ev1):
+    """
+    Apply ionization descaling of [1]_ to energy and cross-section.
+
+    Parameters
+    ----------
+    bte : array-like
+        Scaled energy
+    btx : array-like
+        Scaled cross-section
+    f : float
+        Scaling parameter
+    ev1 : float
+        ionization potential - units determine the output energy units
+
+    Returns
+    -------
+    [energy,cross] : `list`
+        Descaled energy and cross-section
+
+    Notes
+    -----
+    This is the scaling used and discussed in the Dere (2007) calculation [1] of cross sections.  It was derived from similar scalings provided by reference [2]
+
+    See Also
+    --------
+    scale_bti : Descale ionization energy and cross-section
+
+    References
+    ----------
+    .. [1] Dere, K. P., 2007, A&A, `466, 771, <http://adsabs.harvard.edu/abs/2007A%26A...466..771D>`_
+    .. [2] Burgess, A. and Tully, J. A., 1992, A&A, `254, 436 <http://adsabs.harvard.edu/abs/1992A%26A...254..436B>`_
+    """
+    u = 1.-f + np.exp(np.log(f)/(1. - bte))
+    energy = u*ev1
+    cross = (np.log(u)+1.)*btx/(u*ev1**2)
+    return [energy,cross]
+
+
 def scale_bt(evin,omega,f,ev1):
     """
     Apply excitation scaling of [1]_ to energy and collision strength.
@@ -574,3 +573,28 @@ def scale_bt(evin,omega,f,ev1):
     bte=1.-np.log(f)/np.log(u-1.+f)
     btomega=omega/(np.log(u)-1.+np.exp(1.))
     return [bte,btomega]
+    
+def scale_classical(x, y, ip):
+    """
+    to apply the 'classical' scaling to the input data
+    
+    Parameters
+    ----------
+    
+    x: array-like
+        x can be the energy or the temperature.  Typically, the energy is
+        in the same  units as the ionization potential
+    y:  array like
+        y can be the ionization cross-section, ionization rate, or a recombination
+        rate
+    ip:  float
+        the ionization potential.  Typically in eV.
+        
+    Returns
+    -------
+    {'csx':csx, 'csy':csy}
+    """
+    csx = x/ip
+    csy = y*ip**2
+    out = {'csx':csx, 'csy':csy}
+    return out


### PR DESCRIPTION
removed a lot of commented out code
removed easplomRead as it duplicates splomRead
added scale_classical - useful in scaling ionization cross-sections and rates and recombination cross-sections and rates
removed ionrecdatRead as it is not a general ChiantiPy function