### PR TITLE
Pin NumPy version and fix RTD builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ env:
   global:
     - XUVTOP=$HOME"/chianti_dbase"
     - PYTHON_VERSION=2.7
-    - NUMPY_VERSION='stable'
+    #- NUMPY_VERSION='stable'
     - ASTROPY_VERSION='stable'
     - MAIN_CMD='python setup.py'
     - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme pytest'
+    - NUMPY_VERSION='1.11'
     - PYQT_VERSION='4.11.4'
   matrix:
     - PYTHON_VERSION=2.7 SETUP_CMD='install'
@@ -19,9 +20,9 @@ env:
     - PYTHON_VERSION=2.7 SETUP_CMD='test'
     - PYTHON_VERSION=3.4 SETUP_CMD='test'
     - PYTHON_VERSION=3.5 SETUP_CMD='test'
-    - PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx'
-    - PYTHON_VERSION=3.4 SETUP_CMD='build_sphinx'
-    - PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx'
+    - PYTHON_VERSION=2.7 SETUP_CMD='build_docs'
+    - PYTHON_VERSION=3.4 SETUP_CMD='build_docs'
+    - PYTHON_VERSION=3.5 SETUP_CMD='build_docs'
 #install the ci helpers
 install:
   - git clone https://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - mkdir -p $HOME/.chianti
   - cp chiantirc $HOME/.chianti
   - mkdir -p $XUVTOP
-  - curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.2_data.tar.gz | tar xz -C $XUVTOP
+  - if [[ "$SETUP_CMD" == "test" ]]; then curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.2_data.tar.gz | tar xz -C $XUVTOP; fi
 #run the setup commands
 script:
   - $MAIN_CMD $SETUP_CMD

--- a/ChiantiPy/base/_SpecTrails.py
+++ b/ChiantiPy/base/_SpecTrails.py
@@ -12,7 +12,6 @@ import ChiantiPy.tools.util as util
 import ChiantiPy.tools.io as chio
 import ChiantiPy.tools.data as chdata
 import ChiantiPy.tools.constants as const
-defaults = chdata.Defaults
 
 
 class specTrails(object):
@@ -24,7 +23,7 @@ class specTrails(object):
     def __init__(self, temperature, density):
         self.Temperature = temperature
         self.EDensity = density
-        self.AbundanceName = defaults['abundfile']
+        self.AbundanceName = chdata.Defaults['abundfile']
         self.AbundAll = chdata.Abundance[self.AbundanceName]['abundance']
         #
         # ---------------------------------------------------------------------------

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -7,8 +7,6 @@ import ChiantiPy.tools.util as util
 import ChiantiPy.tools.io as chio
 import ChiantiPy.tools.constants as const
 import ChiantiPy.Gui as chGui
-ip = chdata.Ip
-MasterList = chdata.MasterList
 
 
 class continuum:
@@ -48,6 +46,7 @@ class continuum:
                 print(' for %s this is the neutral ions an does not produce a continuum'%(ionStr))
             return
         #  the Ip is only relevant to the free-free methods
+        ip = chdata.Ip
 #        self.Ip = ip[self.Z-1, self.Ion-1]
         self.Ipr = ip[self.Z-1, self.Ion-2]
         #

--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -18,7 +18,6 @@ import ChiantiPy.Gui as chGui
 from ChiantiPy.base import ionTrails
 from ChiantiPy.base import specTrails
 
-xuvtop = chdata.xuvtop
 heseqLvl2 = [-1,3,-1,-1,-1,5,6,6,-1,6,6,6,5,5,3,5,3,5,3,5,-1,-1,-1,-1,-1,4,-1,4,-1,4]
 
 
@@ -588,7 +587,7 @@ class ion(ionTrails, specTrails):
                 x0 = const.ryd2Ev*eaparams['de'][iups]/tev
                 #  upsilon has already been divided by the statistical weight
                 # of the ground level 2j+1
-                earate1 = eaev[iups]*const.collision*eaparams['ups'][iups]*np.exp(-x0)/(np.sqrt(temperature)) 
+                earate1 = eaev[iups]*const.collision*eaparams['ups'][iups]*np.exp(-x0)/(np.sqrt(temperature))
                 partial[iups] = earate1
                 earate += earate1
             self.EaRate = {'rate':earate, 'temperature':temperature, 'partial':partial}

--- a/ChiantiPy/core/IpyMspectrum.py
+++ b/ChiantiPy/core/IpyMspectrum.py
@@ -13,8 +13,6 @@ import ChiantiPy.Gui as chgui
 from ChiantiPy.base import ionTrails
 from ChiantiPy.base import specTrails
 
-defaults = chdata.Defaults
-
 
 class ipymspectrum(ionTrails, specTrails):
     '''
@@ -75,7 +73,7 @@ class ipymspectrum(ionTrails, specTrails):
         #
         setupIntensity = 0
         #
-        self.Defaults = defaults
+        self.Defaults = chdata.Defaults
         #
         self.Temperature = np.asarray(temperature,'float64')
         self.EDensity = np.asarray(eDensity,'float64')

--- a/ChiantiPy/core/Mspectrum.py
+++ b/ChiantiPy/core/Mspectrum.py
@@ -13,8 +13,6 @@ from ChiantiPy.base import ionTrails
 from ChiantiPy.base import specTrails
 import ChiantiPy.tools.mputil as mputil
 
-defaults = chdata.Defaults
-
 
 class mspectrum(ionTrails, specTrails):
     ''' this is the multiprocessing version of spectrum
@@ -64,10 +62,7 @@ class mspectrum(ionTrails, specTrails):
         # creates Intensity dict from first ion calculated
         setupIntensity = 0
         #
-        self.Defaults = defaults
-        #
-#        masterlist = chdata.MasterList
-        self.Defaults = defaults
+        self.Defaults = chdata.Defaults
         self.Temperature = np.asarray(temperature, 'float64')
         nTemp = self.Temperature.size
         self.EDensity = np.asarray(eDensity, 'float64')

--- a/ChiantiPy/core/RadLoss.py
+++ b/ChiantiPy/core/RadLoss.py
@@ -11,7 +11,6 @@ import ChiantiPy.tools.util as util
 import ChiantiPy.Gui as chGui
 from ChiantiPy.base import specTrails
 
-defaults = chdata.Defaults
 
 class radLoss(specTrails):
     '''
@@ -44,7 +43,7 @@ class radLoss(specTrails):
 
     em [for emission measure], can be a float or an array of the same length as the
     temperature/density.
-    
+
     abundance: to select a particular set of abundances, set abundance to the name of a CHIANTI abundance file,
         without the '.abund' suffix, e.g. 'sun_photospheric_1998_grevesse'
         If set to a blank (''), a gui selection menu will popup and allow the selection of an set of abundances
@@ -63,7 +62,7 @@ class radLoss(specTrails):
                         pstring = ' %s not in CHIANTI database'%(one)
                         print(pstring)
             masterlist = alist
-        self.Defaults=defaults
+        self.Defaults=chdata.Defaults
         self.Temperature = np.asarray(temperature, 'float64')
         nTemp = self.Temperature.size
         self.EDensity = np.asarray(eDensity, 'float64')

--- a/ChiantiPy/core/Spectrum.py
+++ b/ChiantiPy/core/Spectrum.py
@@ -12,14 +12,13 @@ import ChiantiPy.Gui as chGui
 from ChiantiPy.base import ionTrails
 from ChiantiPy.base import specTrails
 
-defaults = chdata.Defaults
 
 class spectrum(ionTrails, specTrails):
     '''
     Calculate the emission spectrum as a function of temperature and density.
 
-    one of the convenient things is that all of the instantiated ion classes, determined 
-    through such keywords as 'elementList', 'ionList', and 'minAbund' are kept in a 
+    one of the convenient things is that all of the instantiated ion classes, determined
+    through such keywords as 'elementList', 'ionList', and 'minAbund' are kept in a
     dictionary self.IonInstances where self.IonInstances['mg_7'] is the class instance of
     ChiantiPy.core.ion for 'mg_7'.  All its methods and attributes are available.
 
@@ -34,11 +33,11 @@ class spectrum(ionTrails, specTrails):
     specified wavelength array
 
     the default filter is gaussianR with a resolving power of 1000.  Other filters,
-    such as gaussian, box and lorentz, are available in ChiantiPy.tools.filters.  When 
-    using the box filter, the width should equal the wavelength interval to keep the units 
+    such as gaussian, box and lorentz, are available in ChiantiPy.tools.filters.  When
+    using the box filter, the width should equal the wavelength interval to keep the units
     of the continuum and line spectrum the same.
 
-    Inherited methods include 'intensityList', 'intensityRatio' (between lines of different ions), 
+    Inherited methods include 'intensityList', 'intensityRatio' (between lines of different ions),
     'intensityRatioSave' and 'convolve'
 
     A selection of elements can be make with elementList a list containing the names of elements
@@ -51,7 +50,7 @@ class spectrum(ionTrails, specTrails):
 
     a minimum abundance can be specified so that the calculation can be speeded up
     by excluding elements with a low abundance. The default of minAbund is 1.e-6
-    
+
     With solar photospheric abundances -
 
     setting minAbund = 1.e-4 will include H, He, C, O, Ne
@@ -65,23 +64,23 @@ class spectrum(ionTrails, specTrails):
 
     em [for emission measure] can be a float or an array of the same length as the
     temperature/density
-    
-    keepIons:  set this to keep the ion instances that have been calculated in a dictionary 
+
+    keepIons:  set this to keep the ion instances that have been calculated in a dictionary
     self.IonInstances with the keywords being the CHIANTI-style ion names
-        
-    abundance: to select a particular set of abundances, set abundance to the name of a 
+
+    abundance: to select a particular set of abundances, set abundance to the name of a
     CHIANTI abundance file, without the '.abund' suffix, e.g. 'sun_photospheric_1998_grevesse'
-    
-    If set to a blank (''), a gui selection menu will popup and allow the selection of an 
+
+    If set to a blank (''), a gui selection menu will popup and allow the selection of an
     set of abundances
-    ''' 
+    '''
     def __init__(self, temperature, eDensity, wavelength, filter=(chfilters.gaussianR, 1000.), label=0, elementList = 0, ionList = 0, minAbund=1.e-6, doContinuum=1, em=0, keepIons=0,  abundance=None, verbose=0, allLines=1):
         #
         t1 = datetime.now()
         # creates Intensity dict from first ion calculated
         setupIntensity = 0
         #
-        self.Defaults=defaults
+        self.Defaults=chdata.Defaults
         self.Temperature = np.asarray(temperature, 'float64')
         nTemp = self.Temperature.size
         self.EDensity = np.asarray(eDensity, 'float64')
@@ -231,25 +230,25 @@ class bunch(ionTrails, specTrails):
     '''
     Calculate the emission line spectrum as a function of temperature and density.
 
-    'bunch' is very similar to 'spectrum' except that continuum is not calculated and 
-    the spectrum is not convolved over a filter.  However, this can be done with the 
+    'bunch' is very similar to 'spectrum' except that continuum is not calculated and
+    the spectrum is not convolved over a filter.  However, this can be done with the
     inherited convolve method
 
-    one of the convenient things is that all of the instantiated ion classes, 
-    determined through such keywords as 'elementList', 'ionList', and 'minAbund' are 
-    kept in a dictionary self.IonInstances where self.IonInstances['mg_7'] is the 
-    class instance of ChiantiPy.core.ion for 'mg_7'.  All its methods and attributes 
+    one of the convenient things is that all of the instantiated ion classes,
+    determined through such keywords as 'elementList', 'ionList', and 'minAbund' are
+    kept in a dictionary self.IonInstances where self.IonInstances['mg_7'] is the
+    class instance of ChiantiPy.core.ion for 'mg_7'.  All its methods and attributes
     are available.
 
     includes elemental abundances and ionization equilibria
 
-    the set of abundances, a file in $XUVTOP/abundance, can be set with the keyword 
+    the set of abundances, a file in $XUVTOP/abundance, can be set with the keyword
     argument 'abundanceName'
-    
+
     temperature and density can be arrays but, unless the size of either is one (1),
     the two must have the same size
 
-    Inherited methods include 'intensityList', 'intensityRatio' (between lines of different 
+    Inherited methods include 'intensityList', 'intensityRatio' (between lines of different
     ions), and 'intensityRatioSave' and 'convolve'.
 
     A selection of elements can be make with elementList a list containing the names of elements
@@ -266,7 +265,7 @@ class bunch(ionTrails, specTrails):
     setting minAbund = 1.e-4 will include H, He, C, O, Ne
     setting minAbund = 2.e-5 adds  N, Mg, Si, S, Fe
     setting minAbund = 1.e-6 adds  Na, Al, Ar, Ca, Ni
-    
+
     At least one of elementList, ionList, or minAbund must be set in order for 'bunch' to include
     any ions.
 
@@ -284,7 +283,7 @@ class bunch(ionTrails, specTrails):
         # creates Intensity dict from first ion calculated
         setupIntensity = 0
         #
-        self.Defaults=defaults
+        self.Defaults=chdata.Defaults
         temperature = np.asarray(temperature, 'float64')
         self.Temperature = temperature
         eDensity = np.asarray(eDensity, 'float64')

--- a/ChiantiPy/tools/data.py
+++ b/ChiantiPy/tools/data.py
@@ -12,31 +12,36 @@ Descriptions for `keywordArgs`:
 - `distance` : distance from the central source
 '''
 import os
+import warnings
 
 import ChiantiPy.tools.io as chio
 
-###
-xuvtop = os.environ['XUVTOP']
-#chInteractive=1
-Defaults = chio.defaultsRead()
-Ip = chio.ipRead()
-MasterList = chio.masterListRead()
-IoneqAll = chio.ioneqRead(ioneqname = Defaults['ioneqfile'])
-# gets the version of the CHIANTI database
-ChiantiVersion = chio.versionRead()
-keywordArgs = ['temperature','eDensity','hDensity', 'pDensity','radTemperature', 'rStar', 'distance']
-#
-AbundanceDefault = chio.abundanceRead(abundancename = Defaults['abundfile'])
-abunddir = os.path.join(xuvtop,'abundance')
-filelist = os.listdir(abunddir)
-#
-AbundanceList = []
-for one in filelist:
-    fname = os.path.join(abunddir,one)
-    if os.path.isfile(fname):
-        AbundanceList.append(os.path.splitext(one)[0])
-#for one in abundList:
-#    print(one)
-Abundance = {AbundanceList[0]:chio.abundanceRead(abundancename = AbundanceList[0])}
-for one in AbundanceList[1:]:
-    Abundance[one] = chio.abundanceRead(abundancename = one)
+try:
+    xuvtop = os.environ['XUVTOP']
+    Defaults = chio.defaultsRead()
+    Ip = chio.ipRead()
+    MasterList = chio.masterListRead()
+    IoneqAll = chio.ioneqRead(ioneqname = Defaults['ioneqfile'])
+    ChiantiVersion = chio.versionRead()
+    keywordArgs = ['temperature','eDensity','hDensity', 'pDensity','radTemperature',
+                    'rStar', 'distance']
+    AbundanceDefault = chio.abundanceRead(abundancename = Defaults['abundfile'])
+    abunddir = os.path.join(xuvtop,'abundance')
+    filelist = os.listdir(abunddir)
+
+    AbundanceList = []
+    for one in filelist:
+        fname = os.path.join(abunddir,one)
+        if os.path.isfile(fname):
+            AbundanceList.append(os.path.splitext(one)[0])
+
+    Abundance = {AbundanceList[0]:chio.abundanceRead(abundancename = AbundanceList[0])}
+    for one in AbundanceList[1:]:
+        Abundance[one] = chio.abundanceRead(abundancename = one)
+except (KeyError,IOError) as e:
+    if isinstance(e,KeyError):
+        warnings.warn(
+            'XUVTOP environment variable not set. You will not be able to access any data from the CHIANTI database.')
+    else:
+        warnings.warn(
+            'Cannot find the CHIANTI atomic database at {}. You will not be able to access any data from the CHIANTI database.'.format(xuvtop))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,12 +61,12 @@ import subprocess
 #check if on readthedocs
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if on_rtd:
-    os.environ['XUVTOP'] = os.path.join(os.getcwd(),'chianti_dbase')
-    if not os.path.exists(os.environ['XUVTOP']):
-        os.makedirs(os.environ['XUVTOP'])
-    #note: when version changes, we'll need to update this
-    subprocess.call('curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.2_data.tar.gz | tar xz -C '+os.environ['XUVTOP'], shell=True)
+#if on_rtd:
+#    os.environ['XUVTOP'] = os.path.join(os.getcwd(),'chianti_dbase')
+#    if not os.path.exists(os.environ['XUVTOP']):
+#        os.makedirs(os.environ['XUVTOP'])
+#    #note: when version changes, we'll need to update this
+#    subprocess.call('curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.2_data.tar.gz | tar xz -C '+os.environ['XUVTOP'], shell=True)
 
 # -- Module Mocking -------------------------------------------------------------
 #if on_rtd:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,5 @@
 conda:
   file: rtd_environment.yml
 python:
-  version: 2.7
+  version: 3
   setup_py_install: True

--- a/rtd_environment.yml
+++ b/rtd_environment.yml
@@ -1,78 +1,11 @@
 name: chiantipy
 dependencies:
-- alabaster=0.7.8=py27_0
-- astropy=1.1.2=np111py27_0
-- babel=2.3.3=py27_0
-- backports=1.0=py27_0
-- backports_abc=0.4=py27_0
-- cairo=1.12.18=6
-- cycler=0.10.0=py27_0
-- decorator=4.0.10=py27_0
-- docutils=0.12=py27_2
-- fontconfig=2.11.1=5
-- freetype=2.5.5=1
-- funcsigs=1.0.2=py27_0
-- futures=3.0.5=py27_0
-- get_terminal_size=1.0.0=py27_0
-- imagesize=0.7.1=py27_0
-- ipykernel=4.3.1=py27_0
-- ipyparallel=5.0.1=py27_0
-- ipython=4.2.0=py27_0
-- ipython_genutils=0.1.0=py27_0
-- jinja2=2.8=py27_1
-- jupyter_client=4.2.2=py27_0
-- jupyter_core=4.1.0=py27_0
-- libgfortran=3.0.0=1
-- libpng=1.6.17=0
-- libsodium=1.0.10=0
-- libxml2=2.9.2=0
-- markupsafe=0.23=py27_2
-- matplotlib=1.5.1=np111py27_0
-- mkl=11.3.3=0
-- mock=2.0.0=py27_0
-- numpy=1.11.0=py27_1
-- openssl=1.0.2h=1
-- path.py=8.2.1=py27_0
-- pathlib2=2.1.0=py27_0
-- pbr=1.10.0=py27_0
-- pexpect=4.0.1=py27_0
-- pickleshare=0.7.2=py27_0
-- pip=8.1.2=py27_0
-- pixman=0.32.6=0
-- ptyprocess=0.5.1=py27_0
-- pycairo=1.10.0=py27_0
-- pygments=2.1.3=py27_0
-- pyparsing=2.1.4=py27_0
-- pyqt=4.11.4=py27_3
-- python=2.7.11=0
-- python-dateutil=2.5.3=py27_0
-- pytz=2016.4=py27_0
-- pyzmq=15.2.0=py27_1
-- qt=4.8.7=3
-- readline=6.2=2
-- scipy=0.17.1=np111py27_0
-- setuptools=23.0.0=py27_0
-- simplegeneric=0.8.1=py27_1
-- singledispatch=3.4.0.3=py27_0
-- sip=4.16.9=py27_0
-- six=1.10.0=py27_0
-- snowballstemmer=1.2.1=py27_0
-- sphinx=1.4.1=py27_0
-- sphinx_rtd_theme=0.1.9=py27_0
-- sqlite=3.13.0=0
-- ssl_match_hostname=3.4.0.2=py27_1
-- tk=8.5.18=0
-- tornado=4.3=py27_1
-- traitlets=4.2.1=py27_0
-- wheel=0.29.0=py27_0
-- zeromq=4.1.4=0
-- zlib=1.2.8=3
-- pip:
-  - backports-abc==0.4
-  - backports.shutil-get-terminal-size==1.0.0
-  - backports.ssl-match-hostname==3.4.0.2
-  - ipython-genutils==0.1.0
-  - jupyter-client==4.2.2
-  - jupyter-core==4.1.0
-  - sphinx-rtd-theme==0.1.9
-
+  - python=3.5
+  - astropy
+  - numpy=1.11
+  - scipy
+  - matplotlib
+  - ipython
+  - ipyparallel
+  - pyqt=4.11.4
+  - sphinx_rtd_theme


### PR DESCRIPTION
Pin NumPy version to v1.11 to fix conflicts with Astropy (re: [this issue](https://github.com/astropy/ci-helpers/issues/166)) and PyQt (re: [this issue](https://github.com/ContinuumIO/anaconda-issues/issues/1068)). 

Also allows ChiantiPy to be imported without the database installed and/or the "XUVTOP" keyword set. A warning is issued to the user in either case to alert them that they will not be able to access data from the database. This is to stop our RTD builds from failing by timing out because of download speeds from CHIANTI (re: [this issue](https://github.com/rtfd/readthedocs.org/issues/2591)).