### PR TITLE
Don't load intersphinx inventory when testing documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
     - PYTHON_VERSION=2.7 SETUP_CMD='test'
     - PYTHON_VERSION=3.4 SETUP_CMD='test'
     - PYTHON_VERSION=3.5 SETUP_CMD='test'
-    - PYTHON_VERSION=2.7 SETUP_CMD='build_docs'
-    - PYTHON_VERSION=3.4 SETUP_CMD='build_docs'
-    - PYTHON_VERSION=3.5 SETUP_CMD='build_docs'
+    - PYTHON_VERSION=2.7 SETUP_CMD='build_docs --no-intersphinx'
+    - PYTHON_VERSION=3.4 SETUP_CMD='build_docs --no-intersphinx'
+    - PYTHON_VERSION=3.5 SETUP_CMD='build_docs --no-intersphinx'
 #install the ci helpers
 install:
   - git clone https://github.com/astropy/ci-helpers.git


### PR DESCRIPTION
Adding a flag to the CI docs builds so that they do not try to load other docs during testing. This should shorten the docs builds and prevent possible failures if docs for other projects are unreachable.