### PR TITLE
Update database to v8.0.6 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - mkdir -p $HOME/.chianti
   - cp chiantirc $HOME/.chianti
   - mkdir -p $XUVTOP
-  - if [[ "$SETUP_CMD" == "test" ]]; then curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.2_data.tar.gz | tar xz -C $XUVTOP; fi
+  - if [[ "$SETUP_CMD" == "test" ]]; then curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.6_data.tar.gz | tar xz -C $XUVTOP; fi
 #run the setup commands
 script:
   - $MAIN_CMD $SETUP_CMD


### PR DESCRIPTION
Pull down latest version of database when running tests. Maybe this will also solve transient CI failures because the database cannot be downloaded?