### PR TITLE
Continuum cleanup

### DIFF
--- a/ChiantiPy/__init__.py
+++ b/ChiantiPy/__init__.py
@@ -37,7 +37,7 @@ except ImportError:
 # Actual package imports here:
 # Note this if statement is only here to allow chiantipy to be imported before
 # it's compiled.
-#if not _ASTROPY_SETUP_:
-    ## For ChiantiPy
-    #from . import  version
-    #Version = version._last_generated_version
+if not _ASTROPY_SETUP_:
+    # For ChiantiPy
+    from . import version
+    Version = version._last_generated_version

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -265,8 +265,9 @@ class Continuum(object):
         else:
             zeta_0 = self.Z - self.stage + 1
 
-        f_2 = (0.9*zeta_0*(z_0**4)/(n_0**5)*np.exp(scaled_energy*(z_0**2)/(n_0**2))
-               + 0.42/(n_0**1.5)*(self.stage**4)*np.exp(scaled_energy*(self.stage**2)/((n_0 + 1)**2)))
+        ip = self.ionization_potential - recombined_fblvl['ecm'][0]*ch_const.planck*ch_const.light
+        f_2 = (0.9*zeta_0*(z_0**4)/(n_0**5)*np.exp(scaled_energy*(z_0**2)/(n_0**2) - ip/ch_const.boltzmann/self.temperature)
+               + 0.42/(n_0**1.5)*(self.stage**4))
 
         return scaled_energy*f_2*self.abundance*self.ioneq_one(**kwargs)
 

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -33,6 +33,23 @@ class Continuum(object):
         Line-of-sight emission measure (:math:`\int\mathrm{d}l\,n_en_H`), in units of
         :math:`\mathrm{cm}^{-5}`, or the volumetric emission measure (:math:`\int\mathrm{d}V\,n_en_H`)
         in units of :math:`\mathrm{cm}^{-3}`.
+
+    Examples
+    --------
+    >>> import ChiantiPy.core as ch
+    >>> import numpy as np
+    >>> temperature = np.logspace(4,9,20)
+    >>> cont = ch.Continuum('fe_15',temperature)
+    >>> wavelength = np.arange(1,1000,10)
+    >>> cont.calculate_free_free_emission(wavelength)
+    >>> cont.calculate_free_bound_emission(wavelength, include_abundance=True, include_ioneq=False)
+    >>> cont.calculate_free_free_loss()
+    >>> cont.calculate_free_bound_loss()
+
+    Notes
+    -----
+    The methods for calculating the free-free and free-bound emission and losses return
+    their result to an attribute. See the respective docstrings for more information.
     """
 
     def __init__(self, ion_string,  temperature, abundance=None, emission_measure=None):
@@ -40,7 +57,10 @@ class Continuum(object):
         self.Z = nameDict['Z']
         self.stage = nameDict['Ion']
         self.temperature = np.array(temperature)
-        self.emission_measure = np.array(emission_measure)
+        if emission_measure is None:
+            self.emission_measure = emission_measure
+        else:
+            self.emission_measure = np.array(emission_measure)
         self.ionization_potential = ch_data.Ip[self.Z-1, self.stage-1]*ch_const.ev2Erg
         # Set abundance
         if abundance is not None:
@@ -61,21 +81,25 @@ class Continuum(object):
 
     def calculate_free_free_loss(self, **kwargs):
         """
-        Calculate the free-free energy loss rate of an ion.
+        Calculate the free-free energy loss rate of an ion. The result is returned to the
+        `free_free_loss` attribute.
 
         The free-free radiative loss rate is given by Eq. 5.15a of [1]_. Writing the numerical
         constant in terms of the fine structure constant :math:`\\alpha`,
 
         .. math::
-           \\frac{dW}{dtdV} = \\frac{4\\alpha^3h^2}{3\pi^2m_e}\left(\frac{2\pi k_B}{3m_e}\\right)^{1/2}Z^2T^{1/2}\bar{g}_B
+           \\frac{dW}{dtdV} = \\frac{4\\alpha^3h^2}{3\pi^2m_e}\left(\\frac{2\pi k_B}{3m_e}\\right)^{1/2}Z^2T^{1/2}\\bar{g}_B
 
         where where :math:`Z` is the nuclear charge, :math:`T` is the electron temperature, and
         :math:`\\bar{g}_{B}` is the wavelength-averaged and velocity-averaged Gaunt factor. The
         Gaunt factor is calculated using the methods of [2]_. Note that this expression for the
-        loss rate is just the integral over wavelength of Eq. 5.14a of [1]_, the free-free emission.
+        loss rate is just the integral over wavelength of Eq. 5.14a of [1]_, the free-free emission, and
+        is expressed in units of erg :math:`\mathrm{cm}^3\,\mathrm{s}^{-1}`.
 
         References
         ----------
+        .. [1] Rybicki and Lightman, 1979, Radiative Processes in Astrophysics,
+            `(Wiley-VCH) <http://adsabs.harvard.edu/abs/1986rpa..book.....R>`_
         .. [2] Karzas and Latter, 1961, ApJSS, `6, 167
             <http://adsabs.harvard.edu/abs/1961ApJS....6..167K>`_
         """
@@ -94,7 +118,8 @@ class Continuum(object):
 
     def calculate_free_free_emission(self, wavelength, include_abundance=True, include_ioneq=True, **kwargs):
         """
-        Calculates the free-free emission for a single ion.
+        Calculates the free-free emission for a single ion. The result is returned as a 2D array to
+        the `free_free_emission` attribute.
 
         The free-free emission for the given ion is calculated according Eq. 5.14a of [1]_,
         substituting :math:`\\nu=c/\lambda`, dividing by the solid angle, and writing the numerical
@@ -142,7 +167,7 @@ class Continuum(object):
             prefactor *= self.abundance
         if include_ioneq:
             prefactor *= self.ioneq_one(**kwargs)
-        if self.emission_measure:
+        if self.emission_measure is not None:
             prefactor *= self.emission_measure
         # define exponential factor
         exp_factor = np.exp(-ch_const.planck*(1.e8*ch_const.light)/ch_const.boltzmann
@@ -162,11 +187,24 @@ class Continuum(object):
         """
         Calculates the free-free gaunt factors of [1]_.
 
-            Need some equations here...
+        An analytic fitting formulae for the relativistic Gaunt factor is given by Eq. 4 of [1]_,
 
-        Notes
-        -----
-        The relativistic values are valid for :math:`6<\log_{10}(T)< 8.5` and :math:`-4<\log_{10}(u)<1`
+        .. math::
+           g_{Z} = \sum^{10}_{i,j=0}a_{ij}t^iU^j
+
+        where,
+
+        .. math::
+           t = \\frac{1}{1.25}(\log_{10}{T} - 7.25),\\
+           U = \\frac{1}{2.5}(\log_{10}{u} + 1.5),
+
+        :math:`u=hc/\lambda k_BT`, and :math:`a_{ij}` are the fitting coefficients and are read
+        in using `ChiantiPy.tools.io.itohRead` and are given in Table 4 of [1]_. These values
+        are valid for :math:`6<\log_{10}(T)< 8.5` and :math:`-4<\log_{10}(u)<1`.
+
+        See Also
+        --------
+        ChiantiPy.tools.io.itohRead : Read in Gaunt factor coefficients from [1]_
 
         References
         ----------
@@ -195,12 +233,14 @@ class Continuum(object):
         """
         Calculates the free-free gaunt factor calculations of [1]_.
 
-            Need some equations here.
+        The Gaunt factors of [1]_ are read in using `ChiantiPy.tools.io.gffRead`
+        as a function of :math:`u` and :math:`\gamma^2`. The data are interpolated
+        to the appropriate wavelength and temperature values using
+        `~scipy.ndimage.map_coordinates`.
 
         References
         ----------
-        .. [1] Sutherland, R. S., 1998, MNRAS, `300, 321
-            <http://adsabs.harvard.edu/abs/1998MNRAS.300..321S>`_
+        .. [1] Sutherland, R. S., 1998, MNRAS, `300, 321 <http://adsabs.harvard.edu/abs/1998MNRAS.300..321S>`_
         """
         # calculate scaled quantities
         lower_u = ch_const.planck*(1.e8*ch_const.light)/ch_const.boltzmann/np.outer(self.temperature,wavelength)
@@ -218,12 +258,27 @@ class Continuum(object):
 
     def calculate_free_bound_loss(self, **kwargs):
         """
-        Calculate the free-bound energy loss rate of an ion.
+        Calculate the free-bound energy loss rate of an ion. The result is returned to the
+        `free_bound_loss` attribute.
 
-            Need some equations here...
+        The free-bound loss rate can be calculated by integrating the free-bound emission over the wavelength.
+        This is difficult using the expression in `calculate_free_bound_emission` so we instead use the
+        approach of [1]_ and [2]_. Eq. 1a of [2]_ can be integrated over wavelength to get the free-bound loss rate,
+
+        .. math::
+           \\frac{dW}{dtdV} = C_{ff}\\frac{k}{hc}T^{1/2}G_{fb},
+
+        in units of erg :math:`\mathrm{cm}^3\,\mathrm{s}^{-1}` where :math:`G_{fb}` is the free-bound Gaunt factor as
+        given by Eq. 15 of [2]_ (see `mewe_gaunt_factor` for more details) and :math:`C_{ff}` is the numerical constant
+        as given in Eq. 4 of [1]_ and can be written in terms of the fine structure constant :math:`\\alpha`, in units
+
+        .. math::
+           C_{ff}\\frac{k}{hc} = \\frac{8}{3}\left(\\frac{\pi}{6}\\right)^{1/2}\\frac{h^2\\alpha^3}{\pi^2}\\frac{k_B}{m_e^{3/2}} \\approx 1.43\\times10^{-27}
 
         References
         ----------
+        .. [1] Gronenschild, E.H.B.M. and Mewe, R., 1978, A&AS, `32, 283 <http://adsabs.harvard.edu/abs/1978A%26AS...32..283G>`_
+        .. [2] Mewe, R. et al., 1986, A&AS, `65, 511 <http://adsabs.harvard.edu/abs/1986A%26AS...65..511M>`_
         """
         # Calculate Gaunt factor according to Mewe
         gaunt_factor = self.mewe_gaunt_factor()
@@ -235,13 +290,30 @@ class Continuum(object):
 
     def mewe_gaunt_factor(self, **kwargs):
         """
-        Calculate the Gaunt factor according to [1]_.
+        Calculate the Gaunt factor according to [1]_ for a single ion :math:`Z_z`.
 
-            Need some equations here.
+        Using Eq. 9 of [1]_, the free-bound Gaunt factor for a single ion can be written as,
+
+        .. math::
+           G_{fb}^{Z,z} = \\frac{E_H}{k_BT}\\mathrm{Ab}(Z)\\frac{N(Z,z)}{N(Z)}f(Z,z,n)
+
+        where :math:`E_H` is the ground-state potential of H, :math:`\mathrm{Ab}(Z)` is the
+        elemental abundance, :math:`\\frac{N(Z,z)}{N(Z)}` is the fractional ionization, and
+        :math:`f(Z,z,n)` is given by Eq. 10 and is approximated by Eq 16 as,
+
+        .. math::
+           f(Z,z,n) \\approx f_2(Z,z,n_0) = 0.9\\frac{\zeta_0z_0^4}{n_0^5}\exp{\left(\\frac{E_Hz_0^2}{n_0^2k_BT}\\right)} + 0.42\\frac{z^4}{n_0^{3/2}}\exp{\left(\\frac{E_Hz^2}{(n_0 + 1)^2k_BT}\\right)}
+
+        where :math:`n_0` is the principal quantum number, :math:`z_0` is the effective charge (see Eq. 7 of [1]_),
+        and :math:`\zeta_0` is the number of vacancies in the 0th shell and is given in Table 1 of [1]_.
+        Here it is calculated in the same manner as in `fb_rad_loss.pro <http://www.chiantidatabase.org/idl/continuum/fb_rad_loss.pro>`_
+        of the CHIANTI IDL library. Note that in the expression for :math:`G_{fb}`, we have not included
+        the :math:`N_H/n_e` factor.
+
 
         References
         ----------
-        .. [1]
+        .. [1] Mewe, R. et al., 1986, A&AS, `65, 511 <http://adsabs.harvard.edu/abs/1986A%26AS...65..511M>`_
         """
         # read in free-bound level information for the recombined ion
         recombined_fblvl = ch_io.fblvlRead('.'.join([ch_util.zion2filename(self.Z, self.stage), 'fblvl']))
@@ -273,18 +345,42 @@ class Continuum(object):
 
     def calculate_free_bound_emission(self, wavelength, include_abundance=True, include_ioneq=True, use_verner=True, **kwargs):
         """
-        Calculates the free-bound (radiative recombination) continuum emissivity of an ion.
-        Provides emissivity in units of ergs :math:`\mathrm{cm}^{-2}` :math:`\mathrm{s}^{-1}`
-        :math:`\mathrm{str}^{-1}` :math:`\mathrm{\AA}^{-1}` for an individual ion.
+        Calculate the free-bound emission of an ion. The result is returned as a 2D array to the
+        `free_bound_emission` attribute.
 
-        Need some equations here.
+        The total free-bound continuum emissivity is given by,
 
-        Notes
-        -----
-        - Uses the Gaunt factors of [1]_ for recombination to the ground level
-        - Uses the photoionization cross sections of [2]_ to develop the free-bound cross section
-        - Does not include the elemental abundance or ionization fraction
-        - The specified ion is the target ion
+        .. math::
+           \\frac{dW}{dtdVd\lambda} = \\frac{1}{4\pi}\\frac{2}{hk_Bc^3m_e\sqrt{2\pi k_Bm_e}}\\frac{E^5}{T^{3/2}}\sum_i\\frac{\omega_i}{\omega_0}\sigma_i^{bf}\exp\left(-\\frac{E - I_i}{k_BT}\\right)
+
+        where :math:`E=hc/\lambda` is the photon energy, :math:`\omega_i` and :math:`\omega_0`
+        are the statistical weights of the :math:`i^{\mathrm{th}}` level of the recombined ion
+        and the ground level of the recombing ion, respectively, :math:`\sigma_i^{bf}` is the
+        photoionization cross-section, and :math:`I_i` is the ionization potential of level :math:`i`.
+        This expression comes from Eq. 7 of `Peter Young's notes on free-bound continuum`_.
+
+        The photoionization cross-sections are calculated using the methods of [2]_ for the
+        transitions to the ground state and [1]_ for all other transitions. See
+        `verner_cross_section` and `karzas_cross_section` for more details.
+
+        .. _Peter Young's notes on free-bound continuum: http://www.pyoung.org/chianti/freebound.pdf
+
+        The free-bound emission is in units of erg
+        :math:`\mathrm{cm}^3\mathrm{s}^{-1}\mathrm{\AA}^{-1}\mathrm{str}^{-1}`. If the emission
+        measure has been set, the units will be multiplied by :math:`\mathrm{cm}^{-5}` or
+        :math:`\mathrm{cm}^{-3}`, depending on whether it is the line-of-sight or volumetric
+        emission measure, respectively.
+
+        Parameters
+        ----------
+        wavelength : array-like
+            In units of angstroms
+        include_abundance : `bool`, optional
+            If True, include the ion abundance in the final output.
+        include_ioneq : `bool`, optional
+            If True, include the ionization equilibrium in the final output
+        use_verner : `bool`, optional
+            If True, cross-sections of ground-state transitions using [2]_, i.e. `verner_cross_section`
 
         References
         ----------
@@ -299,9 +395,9 @@ class Continuum(object):
                      * (ch_const.emass*ch_const.boltzmann)**(3./2.)))
         # read the free-bound level information for the recombined and recombining ion
         recombined_fblvl = ch_io.fblvlRead('.'.join([ch_util.zion2filename(self.Z, self.stage), 'fblvl']))
-        recombining_fblvl = ch_io.fblvlRead('.'.join([ch_util.zion2filename(self.Z, self.stage+1), 'fblvl']))
         if 'errorMessage' in recombined_fblvl:
             raise ValueError('No free-bound information available for {}'.format(ch_util.zion2name(self.Z, self.stage)))
+        recombining_fblvl = ch_io.fblvlRead('.'.join([ch_util.zion2filename(self.Z, self.stage+1), 'fblvl']))
         # get the multiplicity of the ground state of the recombining ion
         if 'errorMessage' in recombining_fblvl:
             omega_0 = 1.
@@ -337,7 +433,7 @@ class Continuum(object):
             fb_emiss *= self.abundance
         if include_ioneq:
             fb_emiss *= self.ioneq_one(**kwargs)[:,np.newaxis]
-        if self.emission_measure:
+        if self.emission_measure is not None:
             fb_emiss *= self.emission_measure
         if ch_data.Defaults['flux'] == 'photon':
             fb_emiss /= photon_energy
@@ -348,13 +444,19 @@ class Continuum(object):
 
     def verner_cross_section(self, photon_energy):
         """
-        Calculates the photoionization cross section using data from [1]_.
+        Calculates the photoionization cross-section using data from [1]_ for
+        transitions to the ground state.
 
-        Need some equations here...
+        The photoionization cross-section can be expressed as :math:`\sigma_i^{fb}=F(E/E_0)` where
+        :math:`F` is an analytic fitting formula given by Eq. 1 of [1]_,
 
-        Notes
-        -----
-        The cross section refers to the next lower ionization stage
+        .. math::
+           F(y) = ((y-1)^2 + y_w^2)y^{-Q}(1 + \sqrt{y/y_a})^{-P},
+
+        where :math:`E` is the photon energy, :math:`n` is the principal quantum number,
+        :math:`l` is the orbital quantum number, :math:`Q = 5.5 + l - 0.5P`, and
+        :math:`\sigma_0,E_0,y_w,y_a,P` are fitting paramters. These can be read in using
+        `ChiantiPy.tools.io.vernerRead`.
 
         References
         ----------
@@ -382,9 +484,32 @@ class Continuum(object):
 
     def karzas_cross_section(self, photon_energy, ionization_potential, n, l):
         """
-        Calculate the K&L photoionization cross-sections.
+        Calculate the photoionization cross-sections using the Gaunt factors of [1]_.
 
-        Need some equations here...
+        The free-bound photoionization cross-section is given by,
+
+        .. math::
+           \sigma_i^{bf} = 1.077294\\times8065.54\\times10^{16}\left(\\frac{I_i}{hc}\\right)^2\left(\\frac{hc}{E}\\right)^3\\frac{g_{bf}}{n_i},
+
+        where :math:`I_i` is the ionization potential of the :math:`i^{\mathrm{th}}` level,
+        :math:`E` is the photon energy, :math:`g_{bf}` is the Gaunt factor calculated
+        according to [1]_, and :math:`n_i` is the principal quantum number of the
+        :math:`i^{\mathrm{th}}` level. :math:`\sigma_i^{bf}` is units of :math:`\mathrm{cm}^{2}`.
+        This expression is given in `Peter Young's notes on free-bound continuum`_.
+
+        .. _Peter Young's notes on free-bound continuum: http://www.pyoung.org/chianti/freebound.pdf
+
+        Parameters
+        ----------
+        photon_energy : array-like
+        ionization_potential : `float`
+        n : `int`
+        l : `int`
+
+        References
+        ----------
+        .. [1] Karzas and Latter, 1961, ApJSS, `6, 167
+            <http://adsabs.harvard.edu/abs/1961ApJS....6..167K>`_
         """
         # numerical constant, in Mbarn
         kl_constant = 1.077294e-1*8065.54e3
@@ -406,11 +531,14 @@ class Continuum(object):
         return np.where(photon_energy >= ionization_potential, cross_section, 0.)
 
     def ioneq_one(self, **kwargs):
-        '''
-        Provide the ionization equilibrium for the selected ion as a function of temperature.
-        returned in self.IoneqOne
-        this is a duplicate of the method ion.ioneqOne
-        '''
+        """
+        Calculate the equilibrium fractional ionization of the ion as a function of temperature.
+
+        Uses the ~`ioneq` module and does a first-order spline interpolation to the data. An
+        ionization equilibrium file can be passed as a keyword argument, `ioneqfile`. This can
+        be passed through as a keyword argument to any of the functions that uses the
+        ionization equilibrium.
+        """
         tmp = ioneq(self.Z)
         tmp.load(kwargs.get('ioneqfile', ch_data.Defaults['ioneqfile']))
         ionization_equilibrium = splev(self.temperature,

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -85,7 +85,7 @@ class Continuum(object):
         gaunt_factor = splev(np.log(gamma_squared),
                              splrep(gf_kl_info['g2'],gf_kl_info['gffint']), ext=3)
         # calculate numerical constant
-        prefactor = (4.*(ch_const.alpha**3)*(ch_const.planck**2)/3./(np.pi**2)/ch_const.emass
+        prefactor = (4.*(ch_const.fine**3)*(ch_const.planck**2)/3./(np.pi**2)/ch_const.emass
                      * np.sqrt(2.*np.pi*ch_const.boltzmann/3./ch_const.emass))
 
         self.free_free_loss = prefactor*(self.Z**2)*np.sqrt(self.temperature)*gaunt_factor
@@ -214,7 +214,7 @@ class Continuum(object):
 
         return np.where(gf_sutherland < 0., 0., gf_sutherland)
 
-    def calculate_free_bound_loss(self, wavelength, **kwargs):
+    def calculate_free_bound_loss(self, **kwargs):
         """
         Calculate the free-bound energy loss rate of an ion.
 

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -413,5 +413,5 @@ class Continuum(object):
         tmp = ioneq(self.Z)
         tmp.load(kwargs.get('ioneqfile', ch_data.Defaults['ioneqfile']))
         ionization_equilibrium = splev(self.temperature,
-                                       splrep(tmp.Temperature, tmp.Ioneq[self.stage,:]), ext=1)
+                                       splrep(tmp.Temperature, tmp.Ioneq[self.stage,:], k=1), ext=1)
         return np.where(ionization_equilibrium < 0., 0., ionization_equilibrium)

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -248,7 +248,7 @@ class Continuum(object):
         # thermal energy scaled by H ionization potential
         scaled_energy = ch_const.ryd2erg/ch_const.boltzmann/self.temperature
         # set variables used in Eq. 16 of Mewe et al.(1986)
-        n_0 = recombined_fblvl[0]
+        n_0 = recombined_fblvl['pqn'][0]
         z_0 = np.sqrt(self.ionization_potential/ch_const.ryd2erg)*n_0
 
         # calculate zeta_0, the number of vacancies in the recombining ion
@@ -266,7 +266,7 @@ class Continuum(object):
         f_2 = (0.9*zeta_0*(z_0**4)/(n_0**5)*np.exp(scaled_energy*(z_0**2)/(n_0**2))
                + 0.42/(n_0**1.5)*(self.stage**4)*np.exp(scaled_energy*(self.stage**2)/((n_0 + 1)**2)))
 
-        return scaled_energy*f2*self.abundance*self.ioneq_one(**kwargs)
+        return scaled_energy*f_2*self.abundance*self.ioneq_one(**kwargs)
 
     def calculate_free_bound_emission(self, wavelength, include_abundance=True, include_ioneq=True, use_verner=True, **kwargs):
         """

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -23,7 +23,7 @@ class Continuum(object):
     Parameters
     ----------
     ionStr : `str`
-        CHIANTI notation for the given ion, e.g. 'fe_12' that corresponds to the `Fe XII` ion.
+        CHIANTI notation for the given ion, e.g. 'fe_12' that corresponds to the Fe XII ion.
     temperature : array-like
         In units of Kelvin
     abundance : `float` or `str`, optional
@@ -270,7 +270,7 @@ class Continuum(object):
 
         in units of erg :math:`\mathrm{cm}^3\,\mathrm{s}^{-1}` where :math:`G_{fb}` is the free-bound Gaunt factor as
         given by Eq. 15 of [2]_ (see `mewe_gaunt_factor` for more details) and :math:`C_{ff}` is the numerical constant
-        as given in Eq. 4 of [1]_ and can be written in terms of the fine structure constant :math:`\\alpha`, in units
+        as given in Eq. 4 of [1]_ and can be written in terms of the fine structure constant :math:`\\alpha`,
 
         .. math::
            C_{ff}\\frac{k}{hc} = \\frac{8}{3}\left(\\frac{\pi}{6}\\right)^{1/2}\\frac{h^2\\alpha^3}{\pi^2}\\frac{k_B}{m_e^{3/2}} \\approx 1.43\\times10^{-27}
@@ -310,6 +310,10 @@ class Continuum(object):
         of the CHIANTI IDL library. Note that in the expression for :math:`G_{fb}`, we have not included
         the :math:`N_H/n_e` factor.
 
+        Raises
+        ------
+        ValueError
+            If no .fblvl file is available for this ion
 
         References
         ----------
@@ -381,6 +385,11 @@ class Continuum(object):
             If True, include the ionization equilibrium in the final output
         use_verner : `bool`, optional
             If True, cross-sections of ground-state transitions using [2]_, i.e. `verner_cross_section`
+
+        Raises
+        ------
+        ValueError
+            If no .fblvl file is available for this ion
 
         References
         ----------
@@ -534,7 +543,7 @@ class Continuum(object):
         """
         Calculate the equilibrium fractional ionization of the ion as a function of temperature.
 
-        Uses the ~`ioneq` module and does a first-order spline interpolation to the data. An
+        Uses the `ChiantiPy.core.ioneq` module and does a first-order spline interpolation to the data. An
         ionization equilibrium file can be passed as a keyword argument, `ioneqfile`. This can
         be passed through as a keyword argument to any of the functions that uses the
         ionization equilibrium.

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -87,6 +87,8 @@ class Continuum(object):
         # calculate numerical constant
         prefactor = (4.*(ch_const.fine**3)*(ch_const.planck**2)/3./(np.pi**2)/ch_const.emass
                      * np.sqrt(2.*np.pi*ch_const.boltzmann/3./ch_const.emass))
+        # include abundance and ionization equilibrium
+        prefactor *= self.abundance*self.ioneq_one(**kwargs)
 
         self.free_free_loss = prefactor*(self.Z**2)*np.sqrt(self.temperature)*gaunt_factor
 

--- a/ChiantiPy/core/Mspectrum.py
+++ b/ChiantiPy/core/Mspectrum.py
@@ -177,8 +177,7 @@ class mspectrum(ionTrails, specTrails):
             #
             for iff in range(ffWorkerQSize):
                 thisFreeFree = ffDoneQ.get()
-                if 'rate' in sorted(thisFreeFree.keys()):
-                    freeFree += thisFreeFree['rate']
+                freeFree += thisFreeFree
             for p in ffProcesses:
                 if not isinstance(p, str):
                     p.terminate()
@@ -195,8 +194,7 @@ class mspectrum(ionTrails, specTrails):
             #
             for ifb in range(fbWorkerQSize):
                 thisFreeBound = fbDoneQ.get()
-                if 'rate' in sorted(thisFreeBound.keys()):
-                    freeBound += thisFreeBound['rate']
+                freeBound += thisFreeBound
             for p in fbProcesses:
                 if not isinstance(p, str):
                     p.terminate()

--- a/ChiantiPy/core/Spectrum.py
+++ b/ChiantiPy/core/Spectrum.py
@@ -159,19 +159,20 @@ class spectrum(ionTrails, specTrails):
             if 'ff' in self.Todo[akey]:
                 if verbose:
                     print(' calculating ff continuum for :  %s'%(akey))
-                FF = ChiantiPy.core.continuum(akey, temperature, abundance=abundance, em=em)
-                FF.freeFree(wavelength)
-                if 'errorMessage' not in list(FF.FreeFree.keys()):
-                    freeFree += FF.FreeFree['rate']
+                FF = ChiantiPy.core.Continuum(akey, temperature, abundance=abundance, emission_measure=em)
+                FF.calculate_free_free_emission(wavelength)
+                freeFree += FF.free_free_emission
 
             if 'fb' in self.Todo[akey]:
                 if verbose:
                     print(' calculating fb continuum for :  %s'%(akey))
-                FB = ChiantiPy.core.continuum(akey, temperature, abundance=abundance, em=em)
-                FB.freeBound(wavelength)
-                if 'errorMessage' not in list(FB.FreeBound.keys()):
-                    #  an fblvl file exists for this ions
-                    freeBound += FB.FreeBound['rate']
+                FB = ChiantiPy.core.Continuum(akey, temperature, abundance=abundance, emission_measure=em)
+                try:
+                    FB.calculate_free_bound_emission(wavelength)
+                    freeBound += FB.free_bound_emission
+                except ValueError:
+                    # free-bound information not available for all ions
+                    pass
             if 'line' in self.Todo[akey]:
                 if verbose:
                     print(' calculating spectrum for  :  %s'%(akey))

--- a/ChiantiPy/core/tests/test_Continuum.py
+++ b/ChiantiPy/core/tests/test_Continuum.py
@@ -5,7 +5,7 @@ Tests for the continuum class
 import numpy as np
 import pytest
 
-from ChiantiPy.core import continuum
+from ChiantiPy.core import Continuum
 
 # test ion
 test_ion = 'fe_15'
@@ -14,29 +14,32 @@ temperature_1 = 1e+6
 temperature_2 = np.logspace(5,8,10)
 wavelength = np.linspace(10,100,100)
 # create continuum object for testing
-tmp_cont = continuum(test_ion,temperature_2)
-
+tmp_cont = Continuum(test_ion,temperature_2)
+# create continuum object for which there is no free-bound information available
+tmp_cont_no_fb = Continuum('fe_3',temperature_2)
 
 # test temperature input
 def test_temperature():
-    _tmp_cont = continuum(test_ion,temperature_1)
-    assert np.array(temperature_1)==temperature_1
-    _tmp_cont = continuum(test_ion,temperature_2)
-    assert np.all(temperature_2==tmp_cont.Temperature)
+    _tmp_cont = Continuum(test_ion,temperature_1)
+    assert np.array(temperature_1) == _tmp_cont.temperature
+    _tmp_cont = Continuum(test_ion,temperature_2)
+    assert np.all(temperature_2 == _tmp_cont.temperature)
 
 # test the free-free calculation
-def test_freeFree():
-    # call free-free continuum method
-    tmp_cont.freeFree(wavelength)
-    assert hasattr(tmp_cont,'FreeFree')
-    # check that all expected keys are there
-    # FIXME: need to check 'ff' key too but conditions when it should be there are not clear
-    assert all((k in tmp_cont.FreeFree for k in ('rate','temperature','wvl') ))
+def test_free_free():
+    # call free-free emission and loss rate methods
+    tmp_cont.calculate_free_free_emission(wavelength)
+    assert hasattr(tmp_cont,'free_free_emission')
+    tmp_cont.calculate_free_free_loss()
+    assert hasattr(tmp_cont,'free_free_loss')
 
 # test the free-bound calculation
-def test_freeBound():
-    # free-bound continuum methods
-    tmp_cont.freeBound(wavelength)
-    assert hasattr(tmp_cont,'FreeBound')
-    # check that all expected keys are there
-    assert all((k in tmp_cont.FreeBound for k in ('rate','temperature','wvl') ))
+def test_free_bound():
+    # free-bound emission and loss rate methods
+    tmp_cont.calculate_free_bound_emission(wavelength)
+    assert hasattr(tmp_cont,'free_bound_emission')
+    tmp_cont.calculate_free_bound_loss()
+    assert hasattr(tmp_cont,'free_bound_loss')
+    # test an error being raised if no free-bound information is available
+    with pytest.raises(ValueError, message='Expecting ValueError when no free-bound information is available'):
+        tmp_cont_no_fb.calculate_free_bound_emission(wavelength)

--- a/ChiantiPy/tools/mputil.py
+++ b/ChiantiPy/tools/mputil.py
@@ -21,9 +21,9 @@ def doFfQ(inQ, outQ):
         wavelength = inputs[2]
         abund = inputs[3]
         em = inputs[4]
-        ff = ChiantiPy.core.continuum(ionS, temperature, abundance=abund, em=em)
-        ff.freeFree(wavelength)
-        outQ.put(ff.FreeFree)
+        ff = ChiantiPy.core.Continuum(ionS, temperature, abundance=abund, emission_measure=em)
+        ff.calculate_free_free_emission(wavelength)
+        outQ.put(ff.free_free_emission)
     return
 
 
@@ -45,8 +45,12 @@ def doFbQ(inQ, outQ):
         abund = inputs[3]
         em = inputs[4]
         fb = ChiantiPy.core.continuum(ionS, temperature, abundance=abund, em=em)
-        fb.freeBound(wavelength)
-        outQ.put(fb.FreeBound)
+        try:
+            fb.calculate_free_bound_emission(wavelength)
+            fb_emiss = fb.free_bound_emission
+        except ValueError:
+            fb_emiss = np.zeros((len(temperature),len(wavelength)))
+        outQ.put(fb_emiss)
     return
 
 


### PR DESCRIPTION
Fixes #116. Adjusts all calls to continuum in other modules, fix continuum tests, improve continuum documentation, implements loss function methods for free-free and free-bound. Spectrum and rad loss objects are badly broken without this fix.

One issue with this is the free-bound rad losses in Chianti IDL and ChiantiPy do not match now. I do not know if they matched before. A plot of the Python and IDL results in shown below. The free-free results do not match exactly but are pretty close.

![image](https://cloud.githubusercontent.com/assets/8676141/25247592/e4562dd6-25d0-11e7-9df4-9fe4b668b9eb.png)

Since master is broken right now, I would suggest merging this PR (if the tests pass) and then I can open up a new issue about this discrepancy.
