### PR TITLE
Fix ioneq class and add tests

### DIFF
--- a/ChiantiPy/core/Ioneq.py
+++ b/ChiantiPy/core/Ioneq.py
@@ -10,6 +10,8 @@ import ChiantiPy.tools.io as io
 import ChiantiPy.tools.constants as const
 import ChiantiPy.tools.data as chdata
 
+from .Ion import ion
+
 
 class ioneq(object):
     """

--- a/ChiantiPy/core/tests/test_Continuum.py
+++ b/ChiantiPy/core/tests/test_Continuum.py
@@ -14,32 +14,32 @@ temperature_1 = 1e+6
 temperature_2 = np.logspace(5,8,10)
 wavelength = np.linspace(10,100,100)
 # create continuum object for testing
-tmp_cont = Continuum(test_ion,temperature_2)
+tmp_cont = Continuum(test_ion, temperature_2)
 # create continuum object for which there is no free-bound information available
-tmp_cont_no_fb = Continuum('fe_3',temperature_2)
+tmp_cont_no_fb = Continuum('fe_3', temperature_2)
 
-# test temperature input
+
 def test_temperature():
-    _tmp_cont = Continuum(test_ion,temperature_1)
+    _tmp_cont = Continuum(test_ion, temperature_1)
     assert np.array(temperature_1) == _tmp_cont.temperature
-    _tmp_cont = Continuum(test_ion,temperature_2)
+    _tmp_cont = Continuum(test_ion, temperature_2)
     assert np.all(temperature_2 == _tmp_cont.temperature)
 
-# test the free-free calculation
+
 def test_free_free():
     # call free-free emission and loss rate methods
     tmp_cont.calculate_free_free_emission(wavelength)
-    assert hasattr(tmp_cont,'free_free_emission')
+    assert hasattr(tmp_cont, 'free_free_emission')
     tmp_cont.calculate_free_free_loss()
-    assert hasattr(tmp_cont,'free_free_loss')
+    assert hasattr(tmp_cont, 'free_free_loss')
 
-# test the free-bound calculation
+
 def test_free_bound():
     # free-bound emission and loss rate methods
     tmp_cont.calculate_free_bound_emission(wavelength)
-    assert hasattr(tmp_cont,'free_bound_emission')
+    assert hasattr(tmp_cont, 'free_bound_emission')
     tmp_cont.calculate_free_bound_loss()
-    assert hasattr(tmp_cont,'free_bound_loss')
+    assert hasattr(tmp_cont, 'free_bound_loss')
     # test an error being raised if no free-bound information is available
     with pytest.raises(ValueError, message='Expecting ValueError when no free-bound information is available'):
         tmp_cont_no_fb.calculate_free_bound_emission(wavelength)

--- a/ChiantiPy/core/tests/test_Ion.py
+++ b/ChiantiPy/core/tests/test_Ion.py
@@ -19,58 +19,58 @@ density_1 = 1e+9
 density_2 = np.logspace(5,8,20)
 density_3 = np.logspace(5,8,21)
 # setup an ion object to reuse in several tests
-tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_2)
+tmp_ion = ion(test_ion, temperature=temperature_2, eDensity=density_2)
 
 
 # Check various ways to specify the temperature and density
 def test_temperature_density():
     # TODO: test case where neither are set/ one or the other is not set
     # Two single values
-    _tmp_ion = ion(test_ion,temperature=temperature_1,eDensity=density_1,setup=False)
-    assert _tmp_ion.Temperature==np.array(temperature_1)
-    assert _tmp_ion.EDensity==np.array(density_1)
+    _tmp_ion = ion(test_ion, temperature=temperature_1, eDensity=density_1, setup=False)
+    assert _tmp_ion.Temperature == np.array(temperature_1)
+    assert _tmp_ion.EDensity == np.array(density_1)
     # Multiple temperatures, one density
-    _tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_1,setup=False)
-    assert np.all(_tmp_ion.Temperature==temperature_2)
-    assert np.all(_tmp_ion.EDensity==np.array(temperature_2.size*[density_1]))
+    _tmp_ion = ion(test_ion, temperature=temperature_2, eDensity=density_1, setup=False)
+    assert np.all(_tmp_ion.Temperature == temperature_2)
+    assert np.all(_tmp_ion.EDensity == np.array(temperature_2.size*[density_1]))
     # One temperature, multiple densities
-    _tmp_ion = ion(test_ion,temperature=temperature_1,eDensity=density_2,setup=False)
-    assert np.all(_tmp_ion.Temperature==np.array(density_2.size*[temperature_1]))
-    assert np.all(_tmp_ion.EDensity==density_2)
+    _tmp_ion = ion(test_ion, temperature=temperature_1, eDensity=density_2, setup=False)
+    assert np.all(_tmp_ion.Temperature == np.array(density_2.size*[temperature_1]))
+    assert np.all(_tmp_ion.EDensity == density_2)
     # Two equal-sized temperature and density arrays
-    _tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_2,setup=False)
-    assert np.all(_tmp_ion.Temperature==temperature_2)
-    assert np.all(_tmp_ion.EDensity==density_2)
+    _tmp_ion = ion(test_ion, temperature=temperature_2, eDensity=density_2, setup=False)
+    assert np.all(_tmp_ion.Temperature == temperature_2)
+    assert np.all(_tmp_ion.EDensity == density_2)
     # Two unequal sized temperature and density arrays
     with pytest.raises(ValueError,
-                        message='''Expecting ValueError when temperature and density are not of
+                       message='''Expecting ValueError when temperature and density are not of
                                 equal size.'''):
-        _tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_3,setup=False)
+        _tmp_ion = ion(test_ion, temperature=temperature_2, eDensity=density_3, setup=False)
 
 
 # Check how abundance is set
 def test_abundance():
     # Float value
-    _tmp_ion = ion(test_ion,abundance=0.01,setup=False)
-    assert _tmp_ion.Abundance==0.01
+    _tmp_ion = ion(test_ion, abundance=0.01, setup=False)
+    assert _tmp_ion.Abundance == 0.01
     # FIXME: if setting custom abundance, AbundanceName should not be set, but right
     # now it is by the proton/electron density ratio calculation.
     # Custom filename
-    _tmp_ion = ion(test_ion,abundance='sun_coronal_2012_schmelz',setup=False)
-    assert _tmp_ion.AbundanceName=='sun_coronal_2012_schmelz'
+    _tmp_ion = ion(test_ion, abundance='sun_coronal_2012_schmelz', setup=False)
+    assert _tmp_ion.AbundanceName == 'sun_coronal_2012_schmelz'
     abundance = ch_tools.io.abundanceRead(abundancename='sun_coronal_2012_schmelz')
-    assert _tmp_ion.Abundance==abundance['abundance'][_tmp_ion.Z-1]
+    assert _tmp_ion.Abundance == abundance['abundance'][_tmp_ion.Z-1]
 
 
 # Check CHIANTI file imports
 def test_chianti_files():
-    assert hasattr(tmp_ion,'Elvlc')
-    assert hasattr(tmp_ion,'Wgfa')
-    if tmp_ion.Nscups>0:
-        assert hasattr(tmp_ion,'Scups')
-    if tmp_ion.Ncilvl>0:
-        assert hasattr(tmp_ion,'Cilvl')
-    if tmp_ion.Nreclvl>0:
-        assert hasattr(tmp_ion,'Reclvl')
-    if tmp_ion.Npsplups>0:
-        assert hasattr(tmp_ion,'Psplups')
+    assert hasattr(tmp_ion, 'Elvlc')
+    assert hasattr(tmp_ion, 'Wgfa')
+    if tmp_ion.Nscups > 0:
+        assert hasattr(tmp_ion, 'Scups')
+    if tmp_ion.Ncilvl > 0:
+        assert hasattr(tmp_ion, 'Cilvl')
+    if tmp_ion.Nreclvl > 0:
+        assert hasattr(tmp_ion, 'Reclvl')
+    if tmp_ion.Npsplups > 0:
+        assert hasattr(tmp_ion, 'Psplups')

--- a/ChiantiPy/core/tests/test_Ion.py
+++ b/ChiantiPy/core/tests/test_Ion.py
@@ -1,11 +1,11 @@
 """
-Tests for the ion and ioneq classes.
+Tests for the ion class.
 """
 
 import numpy as np
 import pytest
 
-from ChiantiPy.core import ion,ioneq
+from ChiantiPy.core import ion
 import ChiantiPy.tools as ch_tools
 
 # use an ion with relatively small chianti files
@@ -22,7 +22,7 @@ density_3 = np.logspace(5,8,21)
 tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_2)
 
 
-#Check various ways to specify the temperature and density
+# Check various ways to specify the temperature and density
 def test_temperature_density():
     # TODO: test case where neither are set/ one or the other is not set
     # Two single values
@@ -47,7 +47,8 @@ def test_temperature_density():
                                 equal size.'''):
         _tmp_ion = ion(test_ion,temperature=temperature_2,eDensity=density_3,setup=False)
 
-#Check how abundance is set
+
+# Check how abundance is set
 def test_abundance():
     # Float value
     _tmp_ion = ion(test_ion,abundance=0.01,setup=False)
@@ -60,7 +61,8 @@ def test_abundance():
     abundance = ch_tools.io.abundanceRead(abundancename='sun_coronal_2012_schmelz')
     assert _tmp_ion.Abundance==abundance['abundance'][_tmp_ion.Z-1]
 
-#Check CHIANTI file imports
+
+# Check CHIANTI file imports
 def test_chianti_files():
     assert hasattr(tmp_ion,'Elvlc')
     assert hasattr(tmp_ion,'Wgfa')

--- a/ChiantiPy/core/tests/test_Ioneq.py
+++ b/ChiantiPy/core/tests/test_Ioneq.py
@@ -17,7 +17,7 @@ z = 26
 
 def test_el_input():
     el_ioneq_input = ioneq(el)
-    assert el_ioneq_input.Z = util.el2z(el)
+    assert el_ioneq_input.Z == util.el2z(el)
 
 
 def test_z_input():
@@ -46,4 +46,10 @@ def test_load_ioneq():
     load_ioneq.load()
     assert hasattr(load_ioneq, 'Temperature')
     assert hasattr(load_ioneq, 'Ioneq')
+
+
+def test_load_ioneq_alternate_file():
+    load_ioneq = ioneq(el)
     load_ioneq.load(ioneqName='chianti')
+    assert hasattr(load_ioneq, 'Temperature')
+    assert hasattr(load_ioneq, 'Ioneq')

--- a/ChiantiPy/core/tests/test_Ioneq.py
+++ b/ChiantiPy/core/tests/test_Ioneq.py
@@ -1,0 +1,49 @@
+"""
+Tests for ioneq class
+"""
+
+import numpy as np
+import pytest
+
+import ChiantiPy.tools.util as util
+from ChiantiPy.core import ioneq
+
+temperature = np.logspace(4,9,50)
+# Element and Z should represent the same element
+el = 'Fe'
+z = 26
+
+# TODO: test temperatures out of valid extrapolation range
+
+def test_el_input():
+    el_ioneq_input = ioneq(el)
+    assert el_ioneq_input.Z = util.el2z(el)
+
+
+def test_z_input():
+    z_ioneq_input = ioneq(z)
+
+
+def test_el_z_inputs_same():
+    el_ioneq_input = ioneq(el)
+    z_ioneq_input = ioneq(z)
+    el_ioneq_input.load()
+    z_ioneq_input.load()
+    assert np.all(el_ioneq_input.Temperature == z_ioneq_input.Temperature)
+    assert np.all(el_ioneq_input.Ioneq == z_ioneq_input.Ioneq)
+
+
+def test_calculate_ioneq():
+    calc_ioneq = ioneq(el)
+    calc_ioneq.calculate(temperature)
+    assert hasattr(calc_ioneq, 'Temperature')
+    assert hasattr(calc_ioneq, 'Ioneq')
+    assert np.all(calc_ioneq.Temperature == temperature)
+
+
+def test_load_ioneq():
+    load_ioneq = ioneq(el)
+    load_ioneq.load()
+    assert hasattr(load_ioneq, 'Temperature')
+    assert hasattr(load_ioneq, 'Ioneq')
+    load_ioneq.load(ioneqName='chianti')

--- a/ChiantiPy/core/tests/test_Ioneq.py
+++ b/ChiantiPy/core/tests/test_Ioneq.py
@@ -15,6 +15,7 @@ z = 26
 
 # TODO: test temperatures out of valid extrapolation range
 
+
 def test_el_input():
     el_ioneq_input = ioneq(el)
     assert el_ioneq_input.Z == util.el2z(el)

--- a/ChiantiPy/core/tests/test_RadLoss.py
+++ b/ChiantiPy/core/tests/test_RadLoss.py
@@ -9,12 +9,12 @@ from ChiantiPy.core import radLoss
 
 temperature = np.logspace(5,8,20)
 density = 1e+9
-minAbund=1e-4
+minAbund = 1e-4
 
-#FIXME: should probably look at more cases
+
+# FIXME: should probably look at more cases
 def test_radloss():
-    tmp_radloss = radLoss(temperature,density,minAbund=minAbund)
-    assert all((k in tmp_radloss.RadLoss for k in ('rate','temperature','density','minAbund',
-                                                    'abundance')))
+    tmp_radloss = radLoss(temperature, density, minAbund=minAbund)
+    assert all((k in tmp_radloss.RadLoss for k in ('rate', 'temperature', 'density', 'minAbund', 'abundance')))
 
-#TODO: test plotting
+# TODO: test plotting

--- a/ChiantiPy/core/tests/test_Spectrum.py
+++ b/ChiantiPy/core/tests/test_Spectrum.py
@@ -5,23 +5,23 @@ Tests for the spectrum and bunch classes
 import numpy as np
 import pytest
 
-from ChiantiPy.core import spectrum,bunch
+from ChiantiPy.core import spectrum, bunch
 
-#set temperature, density, wavelength
+# set temperature, density, wavelength
 temperature_1 = np.array([1e+6,4e+6,1e+7])
 temperature_2 = np.logspace(5,8,10)
 density = 1e+9
 wavelength = np.linspace(10,100,1000)
-wavelength_range = [wavelength[0],wavelength[-1]]
-min_abund=1.e-4
-ion_list = ['fe_15','fe_16']
+wavelength_range = [wavelength[0], wavelength[-1]]
+min_abund = 1.e-4
+ion_list = ['fe_15', 'fe_16']
 
-# test the spectrum class
+
 def test_spectrum():
-    _tmp_spec = spectrum(temperature_1,density,wavelength,minAbund=min_abund)
+    _tmp_spec = spectrum(temperature_1, density, wavelength, minAbund=min_abund)
     # TODO: need to assert something here, not clear what exactly to test yet
 
-# test the bunch class
+
 def test_bunch():
-    _tmp_bunch = bunch(temperature_2,density,wvlRange=wavelength_range,ionList=ion_list)
+    _tmp_bunch = bunch(temperature_2, density, wvlRange=wavelength_range, ionList=ion_list)
     # TODO: need to assert something here, not clear what exactly to test yet

--- a/ChiantiPy/tools/filters.py
+++ b/ChiantiPy/tools/filters.py
@@ -1,13 +1,12 @@
-#Author: Ken Dere
-
-''' 
+"""
 Line profile filters for creating synthetic spectra.
-'''
+"""
 
 import numpy as np
 
-def gaussianR(wvl,wvl0, factor=1000.):
-    '''
+
+def gaussianR(wvl, wvl0, factor=1000.):
+    """
     A gaussian filter where the gaussian width is given by `wvl0`/`factor`.
 
     Parameters
@@ -18,17 +17,14 @@ def gaussianR(wvl,wvl0, factor=1000.):
         Wavelength filter should be centered on.
     factor : `~numpy.float64`
         Resolving power
-    '''
-    if factor:
-        std = wvl0/factor
-    else:
-        print(' the resolving power of the gaussianR filter is undefined')
-        return None
-    wvl = np.asarray(wvl, 'float64')
+    """
+    std = wvl0/factor
+    wvl = np.asarray(wvl)
     return np.exp(-0.5*((wvl - wvl0)/std)**2)/(np.sqrt(2.*np.pi)*std)
 
-def gaussian(wvl,wvl0, factor=0):
-    '''
+
+def gaussian(wvl, wvl0, factor=1):
+    """
     A gaussian filter
 
     Parameters
@@ -39,19 +35,15 @@ def gaussian(wvl,wvl0, factor=0):
         Wavelength filter should be centered on.
     factor : `~numpy.float64`
         Gaussian width
-    '''
-    if factor:
-        std = factor
-    else:
-        print(' the width of the gaussian filter is undefined')
-        return None
+    """
     wvl = np.asarray(wvl, 'float64')
     dwvl = wvl - np.roll(wvl, 1)
     dwvl[0] = dwvl[1]
-    return np.exp(-0.5*((wvl - wvl0)/std)**2)/(np.sqrt(2.*np.pi)*std)
-    #
-def boxcar(wvl, wvl0, factor=0):
-    '''
+    return np.exp(-0.5*((wvl - wvl0)/factor)**2)/(np.sqrt(2.*np.pi)*factor)
+
+
+def boxcar(wvl, wvl0, factor=None):
+    """
     Box-car filter
 
     Parameters
@@ -60,28 +52,27 @@ def boxcar(wvl, wvl0, factor=0):
         Wavelength array
     wvl0 : `~numpy.float64`
         Wavelength filter should be centered on.
-    factor : `~numpy.float64`
+    width : `~numpy.float64`
         Full width of the box-car filter
-    '''
+    """
     wvl = np.asarray(wvl, 'float64')
     dwvl = wvl - np.roll(wvl, 1)
     dwvl[0] = dwvl[1]
     one = np.ones_like(wvl)
     zed = np.zeros_like(wvl)
-    if factor:
-        # width must be at least equal to the wavelength step
-        width = max(factor, dwvl.min())
-        print((' width = %10.2e'%(width)))
-    else:
-        print(' the width of the box filter is undefined')
-        return None
-    good1 = (wvl > wvl0 - width/2.)
-    good2 = (wvl < wvl0 + width/2.)
+    if factor is None:
+        factor = dwvl.min()
+    if factor < dwvl.min():
+       raise ValueError('Width must be at least equal to the wavelength step')
+    good1 = (wvl > wvl0 - factor/2.)
+    good2 = (wvl < wvl0 + factor/2.)
     realgood = np.logical_and(good1, good2)
-    return np.where(realgood, one, zed)/(width)
-    #
-def lorentz(wvl, wvl0, factor=0):
-    '''Lorentz profile filter with the exception that all factors are in wavelength units
+    return np.where(realgood, one, zed)/(factor)
+
+
+def lorentz(wvl, wvl0, factor=1):
+    """
+    Lorentz profile filter with the exception that all factors are in wavelength units
     rather than frequency as the lorentz profile is usually defined.
 
     Parameters
@@ -92,34 +83,28 @@ def lorentz(wvl, wvl0, factor=0):
         Wavelength filter should be centered on.
     factor : `~numpy.float64`
         Value of the so-called constant gamma
-    '''
-    if factor:
-        gamma = factor
-    else:
-        print(' the factor gamma of the lorentz filter is undefined')
-        return None
-    wvl = np.asarray(wvl, 'float64')
+    """
+    wvl = np.asarray(wvl)
     dwvl = wvl - np.roll(wvl, 1)
     dwvl[0] = dwvl[1]
-    ltz = (gamma/(2.*np.pi)**2)/((wvl - wvl0)**2 + (gamma/(4.*np.pi))**2)
+    ltz = (factor/(2.*np.pi)**2)/((wvl - wvl0)**2 + (factor/(4.*np.pi))**2)
     return np.abs(ltz/(dwvl*ltz.sum()))
-    #
-def moffat(wvl, wvl0, factor=2.5):
-    '''
-    Moffat profile with parameters suited to Chandra Letg spectra
-    
-    
-    Parameters
 
-    
-    wvl : `~numpy.ndarray` Wavelength array
-    
-    wvl0 : `~numpy.float64` Wavelength the filter is centered on.
-    
-    factor : `~numpy.float64`  Resolving power (TODO: correct description)
-    
-    '''
-    wvl = np.asarray(wvl, 'float64')
+
+def moffat(wvl, wvl0, factor=2.5):
+    """
+    Moffat profile with parameters suited to Chandra Letg spectra
+
+    Parameters
+    ----------
+    wvl : `~numpy.ndarray`
+        Wavelength array
+    wvl0 : `~numpy.float64`
+        Wavelength the filter is centered on.
+    factor : `~numpy.float64`
+        Resolving power (TODO: correct description)
+    """
+    wvl = np.asarray(wvl)
     dwvl = np.abs(wvl[1] - wvl[0])
     moffat = 1./(1.+((wvl - wvl0)/0.0275)**2)**factor
     return moffat/(dwvl*moffat.sum())

--- a/ChiantiPy/tools/filters.py
+++ b/ChiantiPy/tools/filters.py
@@ -52,7 +52,7 @@ def boxcar(wvl, wvl0, factor=None):
         Wavelength array
     wvl0 : `~numpy.float64`
         Wavelength filter should be centered on.
-    width : `~numpy.float64`
+    factor : `~numpy.float64`
         Full width of the box-car filter
     """
     wvl = np.asarray(wvl, 'float64')

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ChiantiPy
 [![Build Status](https://travis-ci.org/chianti-atomic/ChiantiPy.svg?branch=master)](https://travis-ci.org/chianti-atomic/ChiantiPy)
 [![Documentation Status](http://readthedocs.org/projects/chiantipy/badge/?version=latest)](http://chiantipy.readthedocs.io/en/latest/?badge=latest)
+[![Coverage Status](https://coveralls.io/repos/github/chianti-atomic/ChiantiPy/badge.svg?branch=master)](https://coveralls.io/github/chianti-atomic/ChiantiPy?branch=master)
 
 ChiantiPy is the Python interface to the [CHIANTI atomic database](http://www.chiantidatabase.org) for astrophysical spectroscopy.  It provides the capability to calculate the emission line and continuum spectrum of an optically thin plasma based on the data in the CHIANTI database.
 


### PR DESCRIPTION
This PR fixes a problem with an import of `ion` into the `ioneq` class that occurred when the `ion`/`ioneq` file was split up. It also adds tests for `ioneq` so that situations like these do not happen again. 

I've also added a [coveralls](https://coveralls.io/github/chianti-atomic) badge to the README and enabled a coveralls hook on the repo so that the test coverage for this repo is checked for each successful Travis CI build ( not including PRs, I think...). This should help us improve test coverage by showing us where it is lacking. 