### PR TITLE
Add support for coverage reports via coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ env:
     #- NUMPY_VERSION='stable'
     - ASTROPY_VERSION='stable'
     - MAIN_CMD='python setup.py'
-    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme pytest'
+    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme pytest pytest-cov coverage'
     - NUMPY_VERSION='1.11'
     - PYQT_VERSION='4.11.4'
   matrix:
     - PYTHON_VERSION=2.7 SETUP_CMD='install'
     - PYTHON_VERSION=3.4 SETUP_CMD='install'
     - PYTHON_VERSION=3.5 SETUP_CMD='install'
-    - PYTHON_VERSION=2.7 SETUP_CMD='test'
-    - PYTHON_VERSION=3.4 SETUP_CMD='test'
-    - PYTHON_VERSION=3.5 SETUP_CMD='test'
+    - PYTHON_VERSION=2.7 SETUP_CMD='test --coverage'
+    - PYTHON_VERSION=3.4 SETUP_CMD='test --coverage'
+    - PYTHON_VERSION=3.5 SETUP_CMD='test --coverage'
     - PYTHON_VERSION=2.7 SETUP_CMD='build_docs --no-intersphinx'
     - PYTHON_VERSION=3.4 SETUP_CMD='build_docs --no-intersphinx'
     - PYTHON_VERSION=3.5 SETUP_CMD='build_docs --no-intersphinx'
@@ -36,3 +36,5 @@ before_script:
 #run the setup commands
 script:
   - $MAIN_CMD $SETUP_CMD
+after_success:
+  - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='./ChiantiPy/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - mkdir -p $HOME/.chianti
   - cp chiantirc $HOME/.chianti
   - mkdir -p $XUVTOP
-  - if [[ "$SETUP_CMD" == "test" ]]; then curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.6_data.tar.gz | tar xz -C $XUVTOP; fi
+  - if [[ $SETUP_CMD == *test* ]]; then curl -L http://www.chiantidatabase.org/download/CHIANTI_8.0.6_data.tar.gz | tar xz -C $XUVTOP; fi
 #run the setup commands
 script:
   - $MAIN_CMD $SETUP_CMD

--- a/ChiantiPy/tests/coveragerc
+++ b/ChiantiPy/tests/coveragerc
@@ -1,16 +1,11 @@
 [run]
-source = {packagename}
+source = ChiantiPy
 omit =
-   {packagename}/_astropy_init*
-   {packagename}/conftest*
-   {packagename}/cython_version*
-   {packagename}/setup_package*
-   {packagename}/*/setup_package*
-   {packagename}/*/*/setup_package*
-   {packagename}/tests/*
-   {packagename}/*/tests/*
-   {packagename}/*/*/tests/*
-   {packagename}/version*
+   ChiantiPy/_astropy_init*
+   ChiantiPy/conftest*
+   ChiantiPy/*setup_package*
+   ChiantiPy/*tests/*
+   ChiantiPy/version*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
Additions to CI config to enable test coverage reports via coveralls. See the report for ChiantiPy [here](https://coveralls.io/github/chianti-atomic)