### PR TITLE
Fix dimension mismatch in continuum; fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     #- NUMPY_VERSION='stable'
     - ASTROPY_VERSION='stable'
     - MAIN_CMD='python setup.py'
-    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx sphinx_rtd_theme pytest pytest-cov coverage'
+    - CONDA_DEPENDENCIES='scipy matplotlib ipython ipyparallel pyqt sphinx_rtd_theme pytest-cov coverage'
     - NUMPY_VERSION='1.11'
     - PYQT_VERSION='4.11.4'
   matrix:

--- a/ChiantiPy/core/Continuum.py
+++ b/ChiantiPy/core/Continuum.py
@@ -446,7 +446,7 @@ class Continuum(object):
         if include_ioneq:
             fb_emiss *= self.ioneq_one(**kwargs)[:,np.newaxis]
         if self.emission_measure is not None:
-            fb_emiss *= self.emission_measure
+            fb_emiss *= self.emission_measure[:,np.newaxis]
         if ch_data.Defaults['flux'] == 'photon':
             fb_emiss /= photon_energy
         # the final units should be per angstrom


### PR DESCRIPTION
This partially addresses #137 by fixing a possible dimension mismatch when multiplying by the input emission measure. Also (hopefully) fixes the Travis build.