### PR TITLE
Allow imports even if ipyparallel is not installed

### DIFF
--- a/ChiantiPy/core/IpyMspectrum.py
+++ b/ChiantiPy/core/IpyMspectrum.py
@@ -1,8 +1,12 @@
 from datetime import datetime
 import copy
+import warnings
 
 import numpy as np
-from ipyparallel import Client
+try:
+    from ipyparallel import Client
+except ImportError:
+    warnings.warn("ipyparallel not found. You won't be able to use the ipymspectrum module")
 
 import ChiantiPy
 import ChiantiPy.tools.data as chdata


### PR DESCRIPTION
The ipyparallel package is only used by ipymspectrum to do parallel processing in the notebook/IPython shell. This adds an exception to allow imports without error and displays a warning telling the user they won't be able to use ipymspectrum