### PR TITLE
Cleanup for new version file and spectrum/Continuum fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 *.c
 
 # Other generated files
+*/version.py
 */cython_version.py
 htmlcov
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ env:
     - PYTHON_VERSION=2.7 SETUP_CMD='build_docs --no-intersphinx'
     - PYTHON_VERSION=3.4 SETUP_CMD='build_docs --no-intersphinx'
     - PYTHON_VERSION=3.5 SETUP_CMD='build_docs --no-intersphinx'
-# remove the version.py to allow for install
-before_install:
-  - rm ChiantiPy/version.py
 #install the ci helpers
 install:
   - git clone https://github.com/astropy/ci-helpers.git

--- a/ChiantiPy/core/Spectrum.py
+++ b/ChiantiPy/core/Spectrum.py
@@ -161,7 +161,7 @@ class spectrum(ionTrails, specTrails):
                     print(' calculating ff continuum for :  %s'%(akey))
                 FF = ChiantiPy.core.Continuum(akey, temperature, abundance=abundance, emission_measure=em)
                 FF.calculate_free_free_emission(wavelength)
-                freeFree += FF.free_free_emission
+                freeFree += FF.free_free_emission.squeeze()
 
             if 'fb' in self.Todo[akey]:
                 if verbose:
@@ -169,7 +169,7 @@ class spectrum(ionTrails, specTrails):
                 FB = ChiantiPy.core.Continuum(akey, temperature, abundance=abundance, emission_measure=em)
                 try:
                     FB.calculate_free_bound_emission(wavelength)
-                    freeBound += FB.free_bound_emission
+                    freeBound += FB.free_bound_emission.squeeze()
                 except ValueError:
                     # free-bound information not available for all ions
                     pass

--- a/ChiantiPy/core/tests/test_Spectrum.py
+++ b/ChiantiPy/core/tests/test_Spectrum.py
@@ -8,8 +8,10 @@ import pytest
 from ChiantiPy.core import spectrum, bunch
 
 # set temperature, density, wavelength
-temperature_1 = np.array([1e+6,4e+6,1e+7])
-temperature_2 = np.logspace(5,8,10)
+temperature_scalar = 4e6
+temperature_array_1d = np.array([temperature_scalar])
+temperature_array = np.array([1e+6,4e+6,1e+7])
+temperature_array_long = np.logspace(5,8,10)
 density = 1e+9
 wavelength = np.linspace(10,100,1000)
 wavelength_range = [wavelength[0], wavelength[-1]]
@@ -17,11 +19,18 @@ min_abund = 1.e-4
 ion_list = ['fe_15', 'fe_16']
 
 
-def test_spectrum():
-    _tmp_spec = spectrum(temperature_1, density, wavelength, minAbund=min_abund)
-    # TODO: need to assert something here, not clear what exactly to test yet
+def test_spectrum_scalar():
+    _tmp_spec = spectrum(temperature_scalar, density, wavelength, minAbund=min_abund)
+    assert _tmp_spec.Spectrum['intensity'].shape == wavelength.shape
+
+
+def test_spectrum_array():
+    _tmp_spec = spectrum(temperature_array_1d, density, wavelength, minAbund=min_abund)
+    assert _tmp_spec.Spectrum['intensity'].shape == wavelength.shape
+    _tmp_spec = spectrum(temperature_array, density, wavelength, minAbund=min_abund)
+    assert _tmp_spec.Spectrum['intensity'].shape == temperature_array.shape+wavelength.shape
 
 
 def test_bunch():
-    _tmp_bunch = bunch(temperature_2, density, wvlRange=wavelength_range, ionList=ion_list)
+    _tmp_bunch = bunch(temperature_array_long, density, wvlRange=wavelength_range, ionList=ion_list)
     # TODO: need to assert something here, not clear what exactly to test yet


### PR DESCRIPTION
Removes the line I added in the Travis build file to remove the version.py file. No longer needed due to #159. Start ignoring version.py again as it will be autogenerated if a user installs with setup.py

@kdere I've also removed the `__init__.py` in this PR. It is not needed when doing a standard install, but if you think it is necessary when adding ChiantiPy to the path manually, I'll undo that commit. 