### PR TITLE
minor changes to ion.setup and io.elvlcWrite

### DIFF
--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -226,7 +226,7 @@ class ion(ionTrails, specTrails):
         # read the scups/splups file
         if os.path.isfile(scupsfile):
             # happens the case of fe_3 and prob. a few others
-            self.Scups = io.scupsRead(self.IonStr, filename=scupsfile)
+            self.Scups = io.scupsRead(self.IonStr)
             self.Nscups = len(self.Scups['lvl1'])
             nlvlScups = max(self.Scups['lvl2'])
             nlvlList.append(nlvlScups)
@@ -235,7 +235,7 @@ class ion(ionTrails, specTrails):
             nlvlScups = 0
         # read cilvl file
         if os.path.isfile(cilvlfile):
-            self.Cilvl = io.cireclvlRead(self.IonStr,filename = fileName, filetype='cilvl')
+            self.Cilvl = io.cireclvlRead(self.IonStr, filetype='cilvl')
             self.Ncilvl = len(self.Cilvl['lvl1'])
             nlvlCilvl = max(self.Cilvl['lvl2'])
             nlvlList.append(nlvlCilvl)
@@ -243,7 +243,7 @@ class ion(ionTrails, specTrails):
             self.Ncilvl = 0
         #  .reclvl file may not exist
         if os.path.isfile(reclvlfile):
-            self.Reclvl = io.cireclvlRead(self.IonStr, filename=fileName, filetype='reclvl')
+            self.Reclvl = io.cireclvlRead(self.IonStr, filetype='reclvl')
             self.Nreclvl = len(self.Reclvl['lvl1'])
             nlvlReclvl = max(self.Reclvl['lvl2'])
             nlvlList.append(nlvlReclvl)
@@ -252,19 +252,19 @@ class ion(ionTrails, specTrails):
         #  psplups file may not exist
         psplupsfile = fileName +'.psplups'
         if os.path.isfile(psplupsfile):
-            self.Psplups = io.splupsRead(self.IonStr, filename=psplupsfile, filetype='psplups')
+            self.Psplups = io.splupsRead(self.IonStr, filetype='psplups')
             self.Npsplups = len(self.Psplups["lvl1"])
         else:
             self.Npsplups = 0
         # drparams file may not exist
         if os.path.isfile(drParamsFile):
-            self.DrParams = io.drRead(self.IonStr, filename=drParamsFile)
+            self.DrParams = io.drRead(self.IonStr)
         if os.path.isfile(rrParamsFile):
-            self.RrParams = io.rrRead(self.IonStr,filename=rrParamsFile)
+            self.RrParams = io.rrRead(self.IonStr)
 
         #  .auto file may not exist
         if os.path.isfile(autofile):
-            self.Auto = io.autoRead(self.IonStr,filename=autofile, total=True)
+            self.Auto = io.autoRead(self.IonStr, total=True)
             self.Nauto = len(self.Auto['lvl1'])
         else:
             self.Nauto = 0

--- a/ChiantiPy/tools/io.py
+++ b/ChiantiPy/tools/io.py
@@ -662,7 +662,7 @@ def elvlcRead(ions, filename=None, getExtended=False, verbose=False, useTh=True)
     return info
 
 
-def elvlcWrite(info, outfile=None, addLvl=0, includeRyd=False,  includeEv=False):
+def elvlcWrite(info, outfile=None, round=0, addLvl=0, includeRyd=False, includeEv=False):
     '''
     Write Chianti data to .elvlc file.
 
@@ -683,6 +683,8 @@ def elvlcWrite(info, outfile=None, addLvl=0, includeRyd=False,  includeEv=False)
         ref, the references in the literature to the data in the input info
     outfile : `str`
         Output filename. ionS+'.elvlc' (in current directory) if None
+    round : `int`
+        input to `np.round' to round input values to maintain the correct number of significant figures
     addLvl : `int`
         Add a constant value to the index of all levels
     includeRyd : `bool`
@@ -730,7 +732,7 @@ def elvlcWrite(info, outfile=None, addLvl=0, includeRyd=False,  includeEv=False)
         thisTerm = aterm.ljust(29)
         thisLabel = info['label'][i].ljust(4)
 #        print, ' len of thisTerm = ', len(thisTerm)
-        pstring = '%7i%30s%5s%5i%5s%5.1f%15.3f%15.3f'%(i+1+addLvl, thisTerm, thisLabel, info['spin'][i], info['spd'][i],info['j'][i],  info['ecm'][i], info['ecmth'][i])        
+        pstring = '%7i%30s%5s%5i%5s%5.1f%15.3f%15.3f'%(i+1+addLvl, thisTerm, thisLabel, info['spin'][i], info['spd'][i],info['j'][i],  np.round(info['ecm'][i], round), np.round(info['ecmth'][i], round))        
         if includeRyd:
              pstring += ' , %15.8f , %15.8f'%(info['eryd'][i], info['erydth'][i])
         if includeEv:


### PR DESCRIPTION
in ion.setup, the various read statements included the filenames which were redundant

in io.elvlcWrite, added a round keyword argument to control the number of significant places that are written