### PR TITLE
 removed =4.11.4 from the qtpy requirement

### DIFF
--- a/rtd_environment.yml
+++ b/rtd_environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - matplotlib
   - ipython
   - ipyparallel
-  - pyqt=4.11.4
+  - pyqt
   - sphinx_rtd_theme


### PR DESCRIPTION
trying to get readthedocs to work

anaconda just seems to use qtpy for all pyqt stuff including pyside