### PR TITLE
updating the default abundances to 'sun_photospheric_2015_scott'

### DIFF
--- a/ChiantiPy/tools/io.py
+++ b/ChiantiPy/tools/io.py
@@ -353,7 +353,7 @@ def defaultsRead(verbose=False):
     """
     Read in configuration from .chiantirc file or set defaults if one is not found.
     """
-    initDefaults = {'abundfile': 'sun_photospheric_1998_grevesse','ioneqfile': 'chianti', 'wavelength': 'angstrom', 'flux': 'energy','gui':False}
+    initDefaults = {'abundfile': 'sun_photospheric_2015_scott','ioneqfile': 'chianti', 'wavelength': 'angstrom', 'flux': 'energy','gui':False}
     rcfile = os.path.join(os.environ['HOME'],'.chianti/chiantirc')
     if os.path.isfile(rcfile):
         print((' reading chiantirc file'))

--- a/chiantirc
+++ b/chiantirc
@@ -4,7 +4,7 @@ wavelength:  angstrom
 #           flux - energy, photon
 flux:  energy
 #           abundfile - any file in $XUVTOP/abundance
-abundfile:  sun_photospheric_1998_grevesse
+abundfile:  sun_photospheric_2015_scott
 #           ioneqfile - any file in $XUVTOP/ioneq
 ioneqfile:  chianti
 #    to use use gui dialogs to make selection, set to true,


### PR DESCRIPTION
from the comments at the end of the file:
%filename: sun_photospheric_2015_scott.abund
%created for the CHIANTI atomic database by Peter Young, 16-Aug-2017
%abundances (F to Ca):
   Scott et al., 2015, A&A, 573, A25
   DOI: 10.1051/0004-6361/201424109
%abundances (Sc to Ni):
   Scott et al., 2015, A&A, 573, A26
   DOI: 10.1051/0004-6361/201424110
%abundances (Cu & Zn):
   Grevesse et al., 2015, A&A, 573, A27
   DOI: 10.1051/0004-6361/201424111
%abundances (other elements):
   Asplund, M., Grevesse, N., Sauval, A.J., & Scott, P. 2009, ARAA, 47, 481
   DOI: 10.1146/annurev.astro.46.060407.145222
%comment:
   This updates the Asplund et al. (2009) results for elements F and higher. The changes
   are mostly small.
