### PR TITLE
Fixing typo

### DIFF
--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -2930,7 +2930,14 @@ class ion(ioneqOne, ionTrails, specTrails):
         >>> int_ratios = np.linspace(0.1,0.8,20)
         >>> fe12.intensityRatioInterpolate(int_ratios)
         >>> dens_values = fe12.IntensityRatioInterpolated['value']
-            
+           
+        >>> # Same setup but using a 2D array of input data
+        >>> x = 10
+        >>> y = 30
+        >>> int_ratios_map = np.random.random((x,y))
+        >>> fe12.intensityRatioInterpolate(int_ratios_map,verbose=True)
+        >>> dens_values_map = fe12.IntensityRatioInterpolated['value'].reshape((x,y))
+        
         '''
 
         # First, what variable to use
@@ -2957,7 +2964,13 @@ class ion(ioneqOne, ionTrails, specTrails):
             sy = y
         
         # If necessary, flatten the input data in order to handle N-D arrays
-        
+        if len(np.shape(data)) > 1:
+            if verbose:
+                print('Input data have dimensions:')
+                print(np.shape(data))
+                print('They will be flattened!\n')                
+            data = np.array(data).flatten() # In case the data type is list
+            
         #
         if 'lin' in scale:
             y2 = splrep(x, sy, s=0)

--- a/ChiantiPy/core/Ion.py
+++ b/ChiantiPy/core/Ion.py
@@ -2878,21 +2878,75 @@ class ion(ioneqOne, ionTrails, specTrails):
             loss = intensity.sum()
         self.BoundBoundLoss = {'rate':loss, 'temperature':self.Temperature, 'eDensity':self.EDensity}
 
-    def intensityRatioInterpolate(self,data, scale = 'lin', plot=0, verbose=0):
+    def intensityRatioInterpolate(self, data, scale='lin', plot=False, verbose=False):
         '''
-        to take a set of date and interpolate against the IntensityRatio
-        the scale can be one of 'lin'/'linear' [default], 'loglog', 'logx', 'logy',
+        Take a set of data and interpolate against the IntensityRatio.
+        
+        Given a set of intensities ratio data it correlates them to electron density 
+        values. This is done by interpolating against the curve computed from 
+        the IntenstyRatio (dict). For the interpolation, the B-spline representation
+        is used from scipy. 
+        
+        Parameters
+        ----------
+        data : float or array-like 
+            The intensities ratio data to be converted into density values.
+            
+        scale : {'lin', 'loglog', 'logx', 'logy'}, str, default : 'lin'
+            The scale to be used for the interpolation (default 'lin' indicates linear).   
+        
+        plot : bool, default : False
+            If True the input data will be plotted on top of the IntensityRatio
+            curve.
+            
+        verbose : bool, default : False
+            If True displays a message about the physical quantity that was used
+            (i.e. Temperature or Density). 
+            Additionally, prints the interpolated data in pairs of data,value
+            (i.e. input intensities ratio data and corresponding density values).
+
+        Returns 
+        -------
+        
+        Creates the attribute:
+        
+        IntensityRatioInterpolated : dict 
+            Dictionary that contains the input data and the derived density values,
+            with keys 
+            
+            *data* : input intensities ratio (no units)
+                
+            *value* : electron density (:math:`\mathrm{cm^{-3}}`)
+        
+        
+        Examples
+        --------
+        >>> import ChiantiPy.core as ch
+        >>> temp = 10**5.9
+        >>> dens = 10**(np.linspace(8,12,num=50,endpoint=True))
+        >>> fe12 = ch.ion('fe_12',temperature=temp,eDensity=dens)
+        >>> fe12.intensityRatio(wvlRange=[186.,196.])
+        >>> # Select for example lines 186.887 and 195.119 from the GUI
+        >>> int_ratios = np.linspace(0.1,0.8,20)
+        >>> fe12.intensityRatioInterpolate(int_ratios)
+        >>> dens_values = fe12.IntensityRatioInterpolated['value']
+            
         '''
-        # first, what variable to use
+
+        # First, what variable to use
         if self.IntensityRatio['temperature'].max() > self.IntensityRatio['temperature'].min():
             x = self.IntensityRatio['ratio']
             y = self.IntensityRatio['temperature']
             if verbose:
-                print('using temperature with %i5 values'%(len(x)))
+                print('Using temperature with %i5 values'%(len(x)))
                 print(' number of values')
         else:
             x = self.IntensityRatio['ratio']
             y = self.IntensityRatio['eDensity']
+            if verbose:
+                print('Using density with %i5 values'%(len(x)))
+                print(' number of values')
+
         #
         if x[0] > x[-1]:
             x = sorted(x)
@@ -2901,6 +2955,9 @@ class ion(ioneqOne, ionTrails, specTrails):
                 sy.append(y[idx])
         else:
             sy = y
+        
+        # If necessary, flatten the input data in order to handle N-D arrays
+        
         #
         if 'lin' in scale:
             y2 = splrep(x, sy, s=0)
@@ -2928,8 +2985,11 @@ class ion(ioneqOne, ionTrails, specTrails):
                 plt.semilogy(interpolatedData, data, 'bD')
         else:
             print(' scale not understood = %s'%(scale))
-        for i, avalue in enumerate(interpolatedData):
-            print(' data, value = %12.3e %12.3e'%(data[i], avalue))
+
+        if verbose:
+            for i, avalue in enumerate(interpolatedData):
+                print(' data, value = %12.3e %12.3e'%(data[i], avalue))
+
         self.IntensityRatioInterpolated = {'data':data, 'value':interpolatedData}
 
 


### PR DESCRIPTION
Suggested modifications concerning #427.

 ### Modifications 
1. Changed the typo __date__ to __data__
2. Added more detailed description of the function, including sections about parameters,returns and examples. I tried to stay consistent with [PEP 257](https://peps.python.org/pep-0257/) and I followed the structure of [numpy docs](https://numpydoc.readthedocs.io/en/latest/format.html#extended-summary)
3. Extended the utility of the _verbose_ parameter in order for the user to be able to handle the printing of the interpolated values or not
4. Added the ability for the function to receive N-D data as input. I added this because when I was using the function I was working mostly with 2D maps of intensities ratios, so it was more convenient to be able to pass them directly to the function. If you feel that this is outside the scope of this function, feel free to disregarded it. 
